### PR TITLE
Privacy: scope extension to current tab and lock network egress to loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ http://127.0.0.1:8000
 
 No user content is sent to external AI providers.
 
+### Privacy & permissions
+
+Apogee requests the minimum access needed to work:
+
+- **`activeTab` + `scripting`** — page content is read **only from the current
+  tab, only when you click Summarize/Ask**. Nothing runs on pages in the
+  background; there are no persistent, all-sites content scripts.
+- **`host_permissions`** are limited to loopback (`127.0.0.1` / `localhost`) —
+  the extension has no access to external websites.
+- **Content Security Policy** restricts network egress to loopback only
+  (`connect-src http://127.0.0.1:* http://localhost:*`), so the browser itself
+  enforces that no data can be sent to a remote server.
+- **`storage`** is used only to keep your settings and cached summaries locally.
+
 ### Load in Chrome / Chromium (unpacked)
 
 The extension is Manifest V3 and works in Chrome as well as Firefox.

--- a/apogee-extension/manifest.json
+++ b/apogee-extension/manifest.json
@@ -4,9 +4,13 @@
   "version": "0.1.0",
   "description": "Local-first browser summarizer for articles, videos, emails and more.",
 
-  "permissions": ["activeTab", "scripting", "storage", "tabs"],
+  "permissions": ["activeTab", "scripting", "storage"],
 
-  "host_permissions": ["<all_urls>", "http://127.0.0.1:8000/*"],
+  "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
+
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; connect-src http://127.0.0.1:* http://localhost:*; img-src 'self' data:; font-src 'self'"
+  },
 
   "icons": {
     "16": "assets/icon.png",
@@ -19,18 +23,6 @@
   "action": {
     "default_popup": "popup/popup.html"
   },
-
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": [
-        "content/Readability.js",
-        "content/extractors/generic.js",
-        "content/extractors/youtube.js",
-        "content/content.js"
-      ]
-    }
-  ],
 
   "browser_specific_settings": {
     "gecko": {

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -244,10 +244,13 @@ async function injectContentScripts(tabId) {
 }
 
 async function extractFromActiveTab(tab) {
+  // Content scripts are injected on demand (activeTab), not on every page.
+  // The first extraction in a tab has no listener yet, so we inject then
+  // retry. Subsequent extractions in the same tab reuse the injected script.
   try {
     return await sendExtractMessage(tab.id);
   } catch (error) {
-    console.error(error);
+    console.debug("Injecting content scripts on demand:", error.message);
 
     await injectContentScripts(tab.id);
 


### PR DESCRIPTION
## Summary

Follow-up to #1. Strengthens Apogee's local-first / privacy posture by removing broad access the extension did not actually need. Today the extension requests `<all_urls>` + `tabs` and injects content scripts into **every page you visit**; this PR narrows that to the current tab, on demand.

- **On-demand, current-tab-only reading.** Removes the always-on `content_scripts` (which matched `<all_urls>`) and the `<all_urls>` host permission. Page content is now read via `activeTab` + `chrome.scripting` **only when you click Summarize/Ask**. The popup already had an on-demand injection path; this makes it the only path. First extraction in a tab injects then reads; subsequent ones reuse the injected script (no duplicate injection).
- **Drop `tabs` permission.** Only `tabs.query({active})`, `tabs.sendMessage`, and `tabs.create` are used — all covered by `activeTab` or needing no permission.
- **Loopback-only host permissions.** `host_permissions` is now `http://127.0.0.1/*` + `http://localhost/*` (any loopback port, to support `APOGEE_PORT`). No access to external sites.
- **Browser-enforced egress lock.** Adds a `content_security_policy` for extension pages with `connect-src http://127.0.0.1:* http://localhost:*`, so the browser itself guarantees no content can be sent to a remote server — backing the "no data leaves your machine" claim.
- **README:** documents the minimal permission/privacy model.

Net effect: the Chrome install prompt no longer says "read and change your data on all websites."

## Test plan
- [ ] Load unpacked in Chrome; confirm the permission prompt no longer lists all-sites access.
- [ ] Summarize a normal article (first click injects on demand; verify it works).
- [ ] Ask a follow-up question in the same tab (reuses injected script).
- [ ] Summarize a second, different tab (fresh on-demand injection).
- [ ] Confirm `/health` still shows Connected and summaries stream (CSP allows loopback `connect-src`).
- [ ] Verify styling/fonts/icons still load under the new CSP.

Note: leaves logo/branding untouched.