### PR TITLE
fix: WebLLM in-browser correctness & performance fixes

### DIFF
--- a/apogee-backend/apogee/services/summary_service.py
+++ b/apogee-backend/apogee/services/summary_service.py
@@ -43,7 +43,9 @@ def summarize_text(
                         partial += token
                     for line in partial.splitlines():
                         line = line.strip()
-                        if line.startswith("•"):
+                        # Models emit bullets as -, * or • interchangeably;
+                        # filtering on • alone silently dropped whole chunks.
+                        if line[:1] in ("•", "-", "*"):
                             yield line + "\n"
                 return
 

--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -69,18 +69,49 @@ let streamCounter = 0;
 // Active port connections from the popup, keyed by streamId
 const popupPorts = new Map();
 
+// The Chrome action popup closes whenever it loses focus, which is constant.
+// Tearing down the offscreen document (and therefore the loaded MLCEngine +
+// WebGPU device) on every close forces a full model reload on the next use.
+// Instead we keep it alive and only close after a period of inactivity, so
+// consecutive interactions reuse the already-loaded model.
+const OFFSCREEN_IDLE_MS = 5 * 60 * 1000;
+let offscreenIdleTimer = null;
+
+function cancelOffscreenIdleClose() {
+  if (offscreenIdleTimer !== null) {
+    clearTimeout(offscreenIdleTimer);
+    offscreenIdleTimer = null;
+  }
+}
+
+function scheduleOffscreenIdleClose() {
+  cancelOffscreenIdleClose();
+  offscreenIdleTimer = setTimeout(async () => {
+    offscreenIdleTimer = null;
+    // Don't close while a stream is still active.
+    if (popupPorts.size > 0) {
+      scheduleOffscreenIdleClose();
+      return;
+    }
+    try {
+      if (typeof chrome !== "undefined" && chrome.offscreen) {
+        await chrome.offscreen.closeDocument();
+      }
+    } catch (err) {
+      // ignore if already closed
+    }
+    offscreenReady = false;
+    offscreenScriptReady = false;
+  }, OFFSCREEN_IDLE_MS);
+}
+
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name === "popup-lifecycle") {
-    port.onDisconnect.addListener(async () => {
-      try {
-        if (typeof chrome !== "undefined" && chrome.offscreen) {
-          await chrome.offscreen.closeDocument();
-        }
-      } catch (err) {
-        // ignore if already closed
-      }
-      offscreenReady = false;
-      offscreenScriptReady = false;
+    // A popup is open — keep the model warm.
+    cancelOffscreenIdleClose();
+    port.onDisconnect.addListener(() => {
+      // Defer teardown; a new popup may reopen almost immediately.
+      scheduleOffscreenIdleClose();
     });
     return;
   }

--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -63,8 +63,11 @@ async function ensureOffscreenDocument() {
   ]);
 }
 
-// Counter for unique stream IDs
-let streamCounter = 0;
+// Unique stream IDs. A plain counter resets whenever the MV3 service worker is
+// evicted, so IDs could collide across worker restarts; use a UUID instead.
+function nextStreamId() {
+  return crypto.randomUUID();
+}
 
 // Active port connections from the popup, keyed by streamId
 const popupPorts = new Map();
@@ -177,7 +180,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         case "ask": {
           await ensureOffscreenDocument();
 
-          const streamId = String(++streamCounter);
+          const streamId = nextStreamId();
 
           await chrome.runtime.sendMessage({
             target: "offscreen",

--- a/apogee-extension/content/run_extraction.js
+++ b/apogee-extension/content/run_extraction.js
@@ -1,6 +1,0 @@
-try {
-  const result = extractPageContent();
-  document.documentElement.setAttribute("data-apogee-result", JSON.stringify(result));
-} catch (e) {
-  document.documentElement.setAttribute("data-apogee-result", JSON.stringify({ error: e.message || String(e) }));
-}

--- a/apogee-extension/lib/chunk.js
+++ b/apogee-extension/lib/chunk.js
@@ -1,0 +1,50 @@
+// Client-side text chunking for the in-browser WebLLM path.
+// The small quantized models used in-browser (e.g. Qwen2.5-1.5B) have a few-K
+// token context window. The backend already chunks long pages before feeding
+// them to Ollama; the WebLLM path previously sent the entire page in a single
+// prompt, which overflows the context on long articles (the model then throws
+// or silently truncates the *front* of the prompt, dropping the instructions).
+//
+// Sizes are expressed in characters (~4 chars/token as a rough heuristic) so we
+// don't need a tokenizer here. Values are deliberately conservative.
+
+// Max characters of source content to feed into a single generation.
+export const MAX_CHUNK_CHARS = 6000;
+
+// When we can only send one prompt (ask / suggest-questions), hard cap the
+// content so the prompt fits alongside the template and the reserved output.
+export const MAX_SINGLE_PROMPT_CHARS = 8000;
+
+// Split text into chunks of at most `maxChars`, preferring to break on
+// paragraph, then sentence, then whitespace boundaries so we don't cut words.
+export function chunkText(text, maxChars = MAX_CHUNK_CHARS) {
+  const clean = (text || "").trim();
+  if (clean.length <= maxChars) {
+    return clean ? [clean] : [];
+  }
+
+  const chunks = [];
+  let remaining = clean;
+
+  while (remaining.length > maxChars) {
+    const window = remaining.slice(0, maxChars);
+    let splitAt = window.lastIndexOf("\n\n");
+    if (splitAt < maxChars * 0.5) splitAt = window.lastIndexOf(". ");
+    if (splitAt < maxChars * 0.5) splitAt = window.lastIndexOf(" ");
+    if (splitAt <= 0) splitAt = maxChars; // no good boundary — hard cut
+
+    chunks.push(remaining.slice(0, splitAt).trim());
+    remaining = remaining.slice(splitAt).trim();
+  }
+
+  if (remaining) chunks.push(remaining);
+  return chunks;
+}
+
+// Truncate content to fit a single prompt, appending an ellipsis marker so the
+// model knows the input was cut.
+export function truncateForPrompt(text, maxChars = MAX_SINGLE_PROMPT_CHARS) {
+  const clean = (text || "").trim();
+  if (clean.length <= maxChars) return clean;
+  return clean.slice(0, maxChars).trim() + "\n\n[...content truncated...]";
+}

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -2,6 +2,8 @@
 // Receives messages from the service worker, runs inference, and streams tokens back via chrome.runtime port connections.
 // IMPORTANT: We use dynamic imports for @mlc-ai/web-llm and prompt helpers so that message handlers (especially check-webgpu) register immediately without waiting for the heavy ~6 MB web-llm module to load. If the static import fails at the top level, the entire module dies and no handlers register,this was the root cause of the false "WebGPU not supported" bug.
 
+import { chunkText, truncateForPrompt } from "../lib/chunk.js";
+
 let engine = null;
 let currentModelId = null;
 let loadingModelId = null;
@@ -105,14 +107,66 @@ async function streamCompletion(eng, prompt, port, isDisconnected) {
   }
 }
 
-async function generateText(eng, prompt) {
+async function generateText(eng, prompt, maxTokens = 512) {
   const reply = await eng.chat.completions.create({
     messages: [{ role: "user", content: prompt }],
     temperature: 0.3,
-    max_tokens: 512,
+    max_tokens: maxTokens,
   });
 
   return reply.choices?.[0]?.message?.content || "";
+}
+
+function reportProgress(text) {
+  chrome.runtime
+    .sendMessage({
+      target: "service-worker",
+      type: "model-progress",
+      progress: { text, progress: 0 },
+    })
+    .catch(() => {});
+}
+
+// Chunk-aware summarization for the small in-browser models. Long pages are
+// split into context-sized chunks; each chunk is summarized independently and
+// the partial summaries are merged in a final streamed pass (map-reduce),
+// mirroring the backend's behavior. Short pages stream directly.
+async function runSummarize(eng, prompts, pending, port, isDisconnected) {
+  const chunks = chunkText(pending.content);
+
+  if (chunks.length <= 1) {
+    const prompt = prompts.buildSummaryPrompt(
+      pending.title,
+      pending.url,
+      chunks[0] || pending.content || "",
+      pending.mode,
+    );
+    await streamCompletion(eng, prompt, port, isDisconnected);
+    return;
+  }
+
+  const partials = [];
+  for (let i = 0; i < chunks.length; i++) {
+    if (isDisconnected()) return;
+    reportProgress(`Summarizing part ${i + 1} of ${chunks.length}...`);
+    const prompt = prompts.buildSummaryPrompt(
+      pending.title,
+      pending.url,
+      chunks[i],
+      pending.mode,
+    );
+    partials.push((await generateText(eng, prompt, 1024)).trim());
+  }
+
+  if (isDisconnected()) return;
+  reportProgress("Merging summary...");
+  const mergePrompt = prompts.buildSummaryPrompt(
+    pending.title,
+    pending.url,
+    partials.join("\n"),
+    pending.mode,
+  );
+  await streamCompletion(eng, mergePrompt, port, isDisconnected);
 }
 
 const pendingStreams = new Map();
@@ -147,26 +201,23 @@ chrome.runtime.onConnect.addListener((port) => {
       const eng = await ensureEngine(pending.model);
       if (disconnected) return;
       const prompts = await getPrompts();
-      let prompt;
 
       switch (pending.action) {
         case "summarize":
-          prompt = prompts.buildSummaryPrompt(
-            pending.title,
-            pending.url,
-            pending.content,
-            pending.mode,
-          );
+          await runSummarize(eng, prompts, pending, port, () => disconnected);
           break;
 
-        case "ask":
-          prompt = prompts.buildAnswerPrompt(
+        case "ask": {
+          const prompt = prompts.buildAnswerPrompt(
             pending.title,
             pending.url,
-            pending.content,
+            truncateForPrompt(pending.content),
             pending.question,
           );
+          if (disconnected) return;
+          await streamCompletion(eng, prompt, port, () => disconnected);
           break;
+        }
 
         default:
           if (!disconnected) {
@@ -182,9 +233,6 @@ chrome.runtime.onConnect.addListener((port) => {
           }
           return;
       }
-
-      if (disconnected) return;
-      await streamCompletion(eng, prompt, port, () => disconnected);
     } catch (err) {
       if (!disconnected) {
         try {

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -91,11 +91,14 @@ async function checkWebGPUSupport() {
       );
     });
     _webgpuSupported = response?.supported === true;
+    return _webgpuSupported;
   } catch {
-    // If we can't reach the service worker, assume supported and let the offscreen doc surface the real error when inference is attempted.
-    _webgpuSupported = true;
+    // If we can't reach the service worker, optimistically assume support so
+    // the user isn't blocked, and let the offscreen doc surface the real error
+    // at inference time. Do NOT cache this — a transient messaging failure
+    // should not suppress the warning for the rest of the session.
+    return true;
   }
-  return _webgpuSupported;
 }
 
 function buildWebllmModelUI(selectedId) {

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -66,7 +66,29 @@ async function clearStoredSummaries() {
   const keys = Object.keys(stored).filter(
     (k) => k.startsWith("summary:") || k.startsWith("suggested-prompts:"),
   );
-  if (keys.length > 0) await chrome.storage.local.remove(keys);
+  keys.push("cacheOrder");
+  await chrome.storage.local.remove(keys);
+}
+
+// Cap how many pages we keep cached so storage doesn't grow without bound.
+// `cacheOrder` is an insertion-ordered list of { s, p } key pairs used as a
+// simple FIFO eviction index.
+const MAX_CACHED_PAGES = 50;
+
+async function persistSummary(cacheKey, promptsCacheKey, text) {
+  const { cacheOrder = [] } = await chrome.storage.local.get("cacheOrder");
+  const order = cacheOrder.filter((e) => e && e.s !== cacheKey);
+  order.push({ s: cacheKey, p: promptsCacheKey });
+
+  const removeKeys = [];
+  while (order.length > MAX_CACHED_PAGES) {
+    const old = order.shift();
+    if (old?.s) removeKeys.push(old.s);
+    if (old?.p) removeKeys.push(old.p);
+  }
+
+  await chrome.storage.local.set({ [cacheKey]: text, cacheOrder: order });
+  if (removeKeys.length > 0) await chrome.storage.local.remove(removeKeys);
 }
 
 // NOTE: The popup runs in a chrome-extension:// context where navigator.gpu is always undefined. The actual WebGPU context lives in the offscreen document.
@@ -514,7 +536,7 @@ async function summarizeActivePage() {
       );
     }
 
-    await chrome.storage.local.set({ [cacheKey]: text });
+    await persistSummary(cacheKey, promptsCacheKey, text);
     currentSummaryText = text;
     showSummaryContext();
     setSuggestedQuestionsLoading();

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -558,7 +558,13 @@ async function submitQuestion(question) {
       active: true,
       currentWindow: true,
     });
-    const pageData = await extractFromActiveTab(tab);
+    // Reuse the page data captured during summarize when it's for the same
+    // tab/URL; extraction (a full Readability DOM clone) is expensive and
+    // doesn't change between asking questions about the same page.
+    let pageData =
+      currentPageData && currentPageData.url === tab.url
+        ? currentPageData
+        : await extractFromActiveTab(tab);
     if (!pageData) {
       answerBox.textContent = "Could not extract page.";
       return;

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -295,7 +295,9 @@ function escapeHtml(text) {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function renderInline(escapedText) {

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -190,15 +190,9 @@ async function applySettingsToUI(settings) {
 
 async function extractFromActiveTab(tab) {
   const tabId = tab.id;
-  try {
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      func: () => {
-        document.documentElement.removeAttribute("data-apogee-result");
-      },
-    });
-  } catch {}
 
+  // Inject the extractor scripts once if they aren't already present in the
+  // page's isolated world.
   let isAlreadyInjected = false;
   try {
     const checkResult = await chrome.scripting.executeScript({
@@ -208,12 +202,7 @@ async function extractFromActiveTab(tab) {
     isAlreadyInjected = checkResult?.[0]?.result;
   } catch {}
 
-  if (isAlreadyInjected) {
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      files: ["/content/run_extraction.js"],
-    });
-  } else {
+  if (!isAlreadyInjected) {
     await chrome.scripting.executeScript({
       target: { tabId },
       files: [
@@ -222,23 +211,27 @@ async function extractFromActiveTab(tab) {
         "/content/extractors/youtube.js",
         "/content/extractors/gmail.js",
         "/content/content.js",
-        "/content/run_extraction.js",
       ],
     });
   }
 
+  // Return the extractor's result directly. executeScript structured-clones
+  // the return value, so there's no need to round-trip it through a DOM
+  // attribute + JSON.parse (which also mutated the host page).
   const results = await chrome.scripting.executeScript({
     target: { tabId },
     func: () => {
-      const val = document.documentElement.getAttribute("data-apogee-result");
-      document.documentElement.removeAttribute("data-apogee-result");
-      return val ? JSON.parse(val) : null;
+      try {
+        return window.extractPageContent();
+      } catch (e) {
+        return { error: e?.message || String(e) };
+      }
     },
   });
 
   const pageData = results?.[0]?.result;
   if (pageData?.error) throw new Error(pageData.error);
-  return pageData;
+  return pageData || null;
 }
 
 chrome.runtime.onMessage.addListener((message) => {


### PR DESCRIPTION
> [!WARNING]
> **Full disclosure: this PR is entirely vibe-coded / AI-assisted.** I have not
> hand-verified every path against a live WebGPU session. Please review each
> commit critically before merging — the commits are intentionally small and
> independent so you can cherry-pick the ones you agree with and drop the rest.

## Summary
A set of independent fixes for the new in-browser (WebLLM/WebGPU) path and a
couple of adjacent issues. Each is its own commit:

1. **perf(sw): keep offscreen doc alive with idle timeout** — the action popup
   closes on every focus loss, and the old code tore down the offscreen doc
   (and the loaded MLCEngine + WebGPU device) each time, forcing a full model
   reload on the next use. Now kept warm, closed only after 5 min idle.
2. **fix(webllm): chunk/truncate content to fit model context** — the in-browser
   path sent the whole page in one prompt, overflowing the small models'
   context on long articles. Adds `lib/chunk.js` + map-reduce summarize
   (mirrors the backend); ask content is truncated.
3. **perf(popup): reuse extracted page data when asking questions** — avoids
   re-running a full Readability DOM clone on every question.
4. **perf(popup): return extraction result directly from executeScript** —
   removes the DOM-attribute + `JSON.parse` round-trip (3 extra script
   injections that mutated the host page). Deletes unused `run_extraction.js`.
5. **fix(backend): accept -, * and • as bullet markers** — multi-chunk bullet
   summaries silently dropped chunks whose bullets weren't `•`.
6. **fix(popup): don't cache fail-open WebGPU result** — a transient messaging
   failure permanently hid the "WebGPU not supported" warning for the session.
7. **fix(popup): bound the summary cache with FIFO eviction** — cached
   summaries grew without bound; now capped at 50 pages.
8. **fix: UUID stream IDs + escape quotes in escapeHtml** — hardening.

Docs/README changes are intentionally excluded (separate PR #3).

## Test plan
- [ ] `cd apogee-extension && npm install && npm run build` (both targets build — verified locally)
- [ ] Load `dist/chrome` unpacked; summarize a short page (streams directly).
- [ ] Summarize a long page (>6k chars) — verify chunked map-reduce completes without a context-overflow error.
- [ ] Ask a follow-up question — verify no re-extraction and a coherent answer.
- [ ] Close/reopen popup quickly — verify the model is not reloaded each time.
- [ ] Multi-chunk bullets via Ollama backend — verify bullets aren't dropped.