### PR TITLE
feat: add arXiv abstract extractor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,7 @@ The following diagram illustrates how components interact on your local device a
 flowchart TD
     subgraph device["Your Device"]
         subgraph page["Active Tab"]
-            EX["Extractors injected on demand<br/>Readability, YouTube, Bilibili, Wikipedia,<br/>Gmail, Reddit, HN, GitHub, Lobsters"]
+            EX["Extractors injected on demand<br/>Readability, YouTube, Bilibili, Wikipedia,<br/>Gmail, Reddit, HN, GitHub, Lobsters, arXiv"]
             HL["Highlight overlay<br/>scrolls to source text"]
         end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **arXiv abstract extractor.** Custom extractor for arXiv abstract pages (`/abs/*`) that parses paper titles, authors, subjects, arXiv ID, PDF link, and abstract into structured Markdown. (#93)
 - **On-device semantic search for past summaries.** Real-time vector search across saved summary titles and content bodies powered by `all-MiniLM-L6-v2` embeddings, automatically stored and capped alongside cached summaries in local storage. (#9)
 - **Unit test coverage for cleaner module.** Tests for `lib/summarize/cleaner.js` covering whitespace collapsing, line trimming, double-newline collapsing, and already-clean text. (#79)
 - **Unit test coverage for Bilibili extractor.** Extractor tests for `content/extractors/bilibili.js`. (#78)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,7 +55,7 @@ Apogee extension codebase lives in `apogee-extension/`. Below is a breakdown of 
 
 ### 1. `content/` (Tab Context Extractor Scripts)
 
-- **What it Contains**: Scripts injected directly into active browser tabs when you trigger summarization or Q&A. Includes `content.js` (main injection script), `Readability.js` (bundled article parser from Mozilla themselves), and specialized site extractors in `content/extractors/` such as `youtube.js`, `bilibili.js`, `wikipedia.js`, `reddit.js`, `gmail.js`, `hackerNews.js`, `github.js`, `lobsters.js`, and `plainArticle.js`.
+- **What it Contains**: Scripts injected directly into active browser tabs when you trigger summarization or Q&A. Includes `content.js` (main injection script), `Readability.js` (bundled article parser from Mozilla themselves), and specialized site extractors in `content/extractors/` such as `youtube.js`, `bilibili.js`, `wikipedia.js`, `reddit.js`, `gmail.js`, `hackerNews.js`, `github.js`, `lobsters.js`, `arxiv.js`, and `plainArticle.js`.
 - **How to Contribute**: Create a new extractor file in `content/extractors/` that reads DOM nodes cleanly without mutating global window scope. Register your extractor in `lib/extract/pageExtraction.js`, create a static HTML test fixture in `tests/extractors/fixtures/`, and add unit test cases in `tests/extractors/`.
 
 ### 2. `lib/` (Core Application Libraries)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ This document outlines current work, upcoming priorities, and long-term goals fo
 
 - **Extractor Expansion**:
   - Add page extractors for more platforms (Stack Overflow, Mastodon, Lemmy, Discourse, GitLab, Dev.to, Bluesky).
-  - Shipped extractors: YouTube, Bilibili, Wikipedia, Gmail, Reddit, Hacker News, GitHub, Lobsters.
+  - Shipped extractors: YouTube, Bilibili, Wikipedia, Gmail, Reddit, Hacker News, GitHub, Lobsters, arXiv.
   - Keep extractor creation simple so contributors can write unit-tested extractors in Node without running a browser.
 - **Test Coverage**:
   - Expand test suites for existing extractors (Bilibili) and untested library modules (diagnostics, hash, timestamps, mapReduce, viewState).

--- a/apogee-extension/content/content.js
+++ b/apogee-extension/content/content.js
@@ -53,6 +53,11 @@ async function extractPageContent() {
     if (data) return { ...data, isPdf: false };
   }
 
+  if (isHost("arxiv.org")) {
+    const data = extractArxiv();
+    if (data) return { ...data, isPdf: false };
+  }
+
   const data = extractGeneric();
   return { ...data, isPdf: false };
 }

--- a/apogee-extension/content/extractors/arxiv.js
+++ b/apogee-extension/content/extractors/arxiv.js
@@ -1,0 +1,41 @@
+const ARXIV_ABSTRACT_PATH =
+  /^\/abs\/((?:\d{4}\.\d{4,5}|[a-z][a-z0-9.-]*\/\d{7})(?:v\d+)?)\/?$/i;
+
+function arxivField(root, selector, label) {
+  const text = root.querySelector(selector)?.textContent || "";
+  return text
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(new RegExp(`^${label}\\s*:\\s*`, "i"), "")
+    .trim();
+}
+
+function extractArxiv() {
+  const pathMatch = location.pathname.match(ARXIV_ABSTRACT_PATH);
+  if (!pathMatch) return null;
+
+  const root = document.querySelector("#abs");
+  if (!root) return null;
+
+  const arxivId = pathMatch[1];
+  const pdfUrl = new URL(`/pdf/${arxivId}`, location.origin).href;
+  const title = arxivField(root, ".title", "Title");
+  const authors = arxivField(root, ".authors", "Authors");
+  const subjects = arxivField(root, ".subjects", "Subjects");
+  const abstract = arxivField(root, ".abstract", "Abstract");
+  if (!title || !authors || !subjects || !abstract) return null;
+
+  return {
+    type: "article",
+    title,
+    url: location.href,
+    content: [
+      `# ${title}`,
+      `## Authors\n${authors}`,
+      `## Subjects\n${subjects}`,
+      `## arXiv ID\n\`${arxivId}\``,
+      `## PDF\n[Open PDF](${pdfUrl})`,
+      `## Abstract\n${abstract}`,
+    ].join("\n\n"),
+  };
+}

--- a/apogee-extension/eslint.config.js
+++ b/apogee-extension/eslint.config.js
@@ -52,6 +52,7 @@ export default [
         extractLobsters: "readonly",
         extractGitHub: "readonly",
         extractWikipedia: "readonly",
+        extractArxiv: "readonly",
       },
     },
   },

--- a/apogee-extension/lib/extract/pageExtraction.js
+++ b/apogee-extension/lib/extract/pageExtraction.js
@@ -84,6 +84,7 @@ export async function extractFromActiveTab(tab) {
           "/content/extractors/lobsters.js",
           "/content/extractors/github.js",
           "/content/extractors/wikipedia.js",
+          "/content/extractors/arxiv.js",
           "/content/content.js",
         ],
       });

--- a/apogee-extension/tests/extractors/README.md
+++ b/apogee-extension/tests/extractors/README.md
@@ -14,6 +14,7 @@ Read the one closest to what you're building:
 
 | File                 | Shows                                                                   |
 | -------------------- | ----------------------------------------------------------------------- |
+| `arxiv.test.js`      | Clean extraction of title, authors, subjects, and abstract from arXiv   |
 | `bilibili.test.js`   | Subtitle fetch via `chrome` stub, multi-part page selection, null cases |
 | `gmail.test.js`      | The simplest shape: synchronous, DOM only                               |
 | `github.test.js`     | Landing page, issues, and fetching diffs for pull requests              |

--- a/apogee-extension/tests/extractors/arxiv.test.js
+++ b/apogee-extension/tests/extractors/arxiv.test.js
@@ -1,0 +1,126 @@
+import test from "node:test";
+import assert from "node:assert";
+import { loadExtractors } from "./helpers/extractorHarness.js";
+
+const URL_MODERN = "https://arxiv.org/abs/2401.01234v2";
+
+function extract(options = {}) {
+  const { extractArxiv } = loadExtractors({
+    files: ["extractors/arxiv.js"],
+    url: URL_MODERN,
+    fixture: "arxiv-abstract.html",
+    ...options,
+  });
+  return extractArxiv();
+}
+
+test("extractArxiv preserves the four abstract fields", () => {
+  const result = extract();
+
+  assert.strictEqual(result.type, "article");
+  assert.strictEqual(result.title, "A Synthetic Study of Quiet Machines");
+  assert.strictEqual(result.url, URL_MODERN);
+  assert.match(result.content, /^# A Synthetic Study of Quiet Machines$/m);
+  assert.match(result.content, /^## Authors\nAlice Example, Bob Example$/m);
+  assert.match(
+    result.content,
+    /^## Subjects\nArtificial Intelligence \(cs\.AI\); Computation and Language \(cs\.CL\)$/m,
+  );
+  assert.match(result.content, /^## arXiv ID\n`2401\.01234v2`$/m);
+  assert.match(
+    result.content,
+    /^## PDF\n\[Open PDF\]\(https:\/\/arxiv\.org\/pdf\/2401\.01234v2\)$/m,
+  );
+  assert.match(
+    result.content,
+    /^## Abstract\nWe describe a fictional machine that sorts imaginary signals while preserving their order\./m,
+  );
+});
+
+test("extractArxiv strips descriptor labels and page furniture", () => {
+  const content = extract().content;
+
+  for (const gone of [
+    "Title:",
+    "Authors:",
+    "Subjects:",
+    "Abstract:",
+    "View PDF",
+    "HTML paper",
+    "Submission history",
+    "Citation tools",
+    "Related papers",
+    "arXivLabs",
+    "Download controls",
+    "site navigation",
+  ]) {
+    assert.ok(!content.includes(gone), `expected "${gone}" to be excluded`);
+  }
+});
+
+test("extractArxiv supports historical identifiers containing a slash", () => {
+  const result = extract({ url: "https://arxiv.org/abs/hep-th/9901001v3" });
+
+  assert.strictEqual(result.type, "article");
+  assert.match(result.content, /^## arXiv ID\n`hep-th\/9901001v3`$/m);
+  assert.match(
+    result.content,
+    /^## PDF\n\[Open PDF\]\(https:\/\/arxiv\.org\/pdf\/hep-th\/9901001v3\)$/m,
+  );
+  assert.match(result.content, /^## Abstract$/m);
+});
+
+test("extractArxiv returns null for non-abstract arXiv pages", () => {
+  for (const url of [
+    "https://arxiv.org/",
+    "https://arxiv.org/list/cs.AI/recent",
+    "https://arxiv.org/search/?query=quiet+machines&searchtype=all",
+    "https://arxiv.org/pdf/2401.01234",
+    "https://arxiv.org/html/2401.01234",
+  ]) {
+    assert.strictEqual(extract({ url }), null, `expected null for ${url}`);
+  }
+});
+
+test("extractArxiv returns null for malformed or missing abstracts", () => {
+  assert.strictEqual(
+    extract({ url: "https://arxiv.org/abs/not-an-identifier" }),
+    null,
+  );
+  assert.strictEqual(
+    extract({
+      html: `<div id="abs">
+               <h1 class="title">Title: Incomplete Paper</h1>
+               <div class="authors">Authors: Alice Example</div>
+               <div class="subjects">Subjects: Artificial Intelligence</div>
+             </div>`,
+      fixture: undefined,
+    }),
+    null,
+  );
+  assert.strictEqual(
+    extract({
+      html: `<div id="abs">
+               <h1 class="title">Title: Incomplete Paper</h1>
+               <div class="authors">Authors: Alice Example</div>
+               <div class="subjects">Subjects: Artificial Intelligence</div>
+               <blockquote class="abstract">Abstract:</blockquote>
+             </div>`,
+      fixture: undefined,
+    }),
+    null,
+  );
+});
+
+test("extractArxiv reads the DOM without a network dependency", () => {
+  let fetched = false;
+  const result = extract({
+    fetch() {
+      fetched = true;
+      throw new Error("unexpected fetch");
+    },
+  });
+
+  assert.strictEqual(result.type, "article");
+  assert.strictEqual(fetched, false);
+});

--- a/apogee-extension/tests/extractors/arxiv.test.js
+++ b/apogee-extension/tests/extractors/arxiv.test.js
@@ -82,6 +82,25 @@ test("extractArxiv returns null for non-abstract arXiv pages", () => {
   }
 });
 
+test("arXiv PDF pages use the existing PDF extraction path", async () => {
+  const context = loadExtractors({
+    files: ["extractors/arxiv.js", "content.js"],
+    url: "https://arxiv.org/pdf/2401.01234",
+    fixture: "arxiv-abstract.html",
+  });
+  Object.defineProperty(context.document, "contentType", {
+    value: "application/pdf",
+    configurable: true,
+  });
+
+  const result = await context.window.extractPageContent();
+
+  assert.strictEqual(result.title, "A Synthetic Study of Quiet Machines");
+  assert.strictEqual(result.url, "https://arxiv.org/pdf/2401.01234");
+  assert.strictEqual(result.content, null);
+  assert.strictEqual(result.isPdf, true);
+});
+
 test("extractArxiv returns null for malformed or missing abstracts", () => {
   assert.strictEqual(
     extract({ url: "https://arxiv.org/abs/not-an-identifier" }),

--- a/apogee-extension/tests/extractors/fixtures/arxiv-abstract.html
+++ b/apogee-extension/tests/extractors/fixtures/arxiv-abstract.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>A Synthetic Study of Quiet Machines</title>
+  </head>
+  <body>
+    <nav>arXiv navigation and search</nav>
+    <main id="content">
+      <div class="full-text">
+        <a href="/pdf/2401.01234">View PDF</a>
+        <a href="/html/2401.01234">HTML paper</a>
+      </div>
+
+      <div id="abs">
+        <h1 class="title mathjax">
+          <span class="descriptor">Title:</span>
+          A Synthetic Study of Quiet Machines
+        </h1>
+        <div class="authors">
+          <span class="descriptor">Authors:</span>
+          <a href="/search/?searchtype=author">Alice Example</a>,
+          <a href="/search/?searchtype=author">Bob Example</a>
+        </div>
+        <table class="metatable">
+          <tr>
+            <td class="tablecell label">Subjects:</td>
+            <td class="tablecell subjects">
+              <span class="descriptor">Subjects:</span>
+              Artificial Intelligence (cs.AI); Computation and Language (cs.CL)
+            </td>
+          </tr>
+        </table>
+        <blockquote class="abstract mathjax">
+          <span class="descriptor">Abstract:</span>
+          We describe a fictional machine that sorts imaginary signals while
+          preserving their order. The synthetic results illustrate the method
+          without reproducing any real paper.
+        </blockquote>
+      </div>
+
+      <section class="submission-history">
+        Submission history: invented dates and download sizes
+      </section>
+      <section class="citation-tools">Citation tools and bibliographic data</section>
+      <section class="recommender">Related papers and recommender tools</section>
+      <section class="arxivlabs">arXivLabs experimental content</section>
+      <footer>Download controls and site navigation</footer>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- add a DOM-only extractor for modern and historical arXiv abstract URLs
- preserve title, authors, subjects, arXiv ID, PDF link, and abstract as clean Markdown
- register the extractor before the generic Readability fallback
- add a trimmed synthetic fixture and focused null/network tests

## Readability verification

On https://arxiv.org/abs/1706.03762, the generic extractor returned the correct title, abstract, and subjects, but omitted the authors and retained PDF/HTML controls, comments, citation metadata, and the full submission history. The dedicated extractor keeps only the requested metadata and abstract.

## Validation

- npm run format:check
- npm run lint
- npm test (250 passing)
- npm run build (Chrome and Firefox)

Closes #20