### PR TITLE
fix: isolate cached output by translation engine

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -624,6 +624,7 @@ async function runBackgroundSummarize(
       model,
       settings.summaryLanguage,
       settings.customInstructions,
+      settings.translationEngine,
     ),
     promptsCacheKey: await getPromptsCacheKey(
       cacheUrl,
@@ -631,6 +632,7 @@ async function runBackgroundSummarize(
       model,
       settings.summaryLanguage,
       settings.customInstructions,
+      settings.translationEngine,
     ),
     persist,
     persistUrl: tab.url,
@@ -684,6 +686,8 @@ async function runBackgroundSummarize(
     url: tab.url,
     streamId,
     promptsCacheKey: finalize.promptsCacheKey,
+    summaryLanguage: settings.summaryLanguage,
+    translationEngine: settings.translationEngine,
   });
 }
 
@@ -870,13 +874,19 @@ async function fetchBilibiliSubtitles({ aid, bvid, cid, preferredLang }) {
 async function generateOllamaSuggestions(
   host,
   model,
-  { title, url, summary, language },
+  { title, url, summary, language, translationEngine },
 ) {
   const validHost = validateOllamaHost(host);
   const prompt = buildSuggestQuestionsPrompt(title, url, summary);
   const chat = (p, opts) => chatStream(validHost, model, p, opts);
   const qLanguage = await resolveEffectiveLanguage(summary, language);
-  const text = await generateInTargetLanguage(chat, prompt, qLanguage);
+  const translateFn =
+    translationEngine === TRANSLATION_ENGINES.OPUS
+      ? makeOpusTranslateFn(() => {})
+      : undefined;
+  const text = await generateInTargetLanguage(chat, prompt, qLanguage, {
+    translateFn,
+  });
   return parseSuggestedQuestions(text);
 }
 
@@ -909,6 +919,7 @@ async function runSuggestQuestionsJob(payload) {
           url,
           summary,
           language,
+          translationEngine,
         });
       } else if (providerType === PROVIDERS.TRANSFORMERS && !hasOffscreenAPI) {
         questions = await generateTransformersSuggestions(model, {
@@ -998,6 +1009,8 @@ async function finalizeSummaryJob({ finalize, model, title, url, text }) {
       streamId: null,
       summaryText: text,
       promptsCacheKey,
+      summaryLanguage: language,
+      translationEngine,
     });
   }
   runSuggestQuestionsJob({

--- a/apogee-extension/lib/storage/pageCache.js
+++ b/apogee-extension/lib/storage/pageCache.js
@@ -1,4 +1,5 @@
 import { getSettings } from "./settings.js";
+import { TRANSLATION_ENGINES } from "../constants.js";
 import { sha256Hex } from "../util/hash.js";
 import { createLock } from "../util/mutex.js";
 import { embedTexts as defaultEmbedTexts } from "../engines/embeddings.js";
@@ -18,16 +19,22 @@ export async function hashUrl(url) {
 // Everything that changes the generated text has to be part of the key, or a
 // cached answer from the old settings comes back and the change looks ignored.
 // That means the url, the response format, the model, the output language, and
-// the custom instructions, which are folded into the prompt. Anything else that
-// starts feeding the prompt belongs here too.
+// the custom instructions, and the translation engine. Anything else that
+// starts shaping the output belongs here too.
 //
-// The instructions suffix is left off entirely when there are none, so keys for
-// the default settings keep the shape they had before custom instructions
-// existed and those cached summaries stay reachable.
+// Legacy keys do not identify their translation engine and cannot safely be
+// assigned to either one, so engine-aware lookups intentionally do not reuse
+// them. They remain available in history until normal eviction or a cache wipe.
 async function instructionsSuffix(customInstructions) {
   const extra = (customInstructions || "").trim();
   if (!extra) return "";
   return `:i${(await sha256Hex(extra)).slice(0, 12)}`;
+}
+
+function translationEngineKey(translationEngine = TRANSLATION_ENGINES.OPUS) {
+  return translationEngine === TRANSLATION_ENGINES.OPUS
+    ? TRANSLATION_ENGINES.OPUS
+    : TRANSLATION_ENGINES.LLM;
 }
 
 export async function getSummaryCacheKey(
@@ -36,8 +43,9 @@ export async function getSummaryCacheKey(
   model,
   lang = "auto",
   customInstructions = "",
+  translationEngine = TRANSLATION_ENGINES.OPUS,
 ) {
-  return `summary:${fmt}:${lang}:${model}:${await hashUrl(url)}${await instructionsSuffix(customInstructions)}`;
+  return `summary:${fmt}:${lang}:${model}:${translationEngineKey(translationEngine)}:${await hashUrl(url)}${await instructionsSuffix(customInstructions)}`;
 }
 export async function getPromptsCacheKey(
   url,
@@ -45,8 +53,9 @@ export async function getPromptsCacheKey(
   model,
   lang = "auto",
   customInstructions = "",
+  translationEngine = TRANSLATION_ENGINES.OPUS,
 ) {
-  return `suggested-prompts:${fmt}:${lang}:${model}:${await hashUrl(url)}${await instructionsSuffix(customInstructions)}`;
+  return `suggested-prompts:${fmt}:${lang}:${model}:${translationEngineKey(translationEngine)}:${await hashUrl(url)}${await instructionsSuffix(customInstructions)}`;
 }
 export async function getContentCacheKey(url) {
   return `content:${await hashUrl(url)}`;

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -163,6 +163,7 @@ if (versionText) {
 let currentPageData = null;
 let currentSummaryText = "";
 let currentSummaryLanguage = null;
+let currentTranslationEngine = null;
 
 const LANGUAGE_LABELS = new Map(
   SUMMARY_LANGUAGES.map((l) => [l.code, l.label]),
@@ -172,18 +173,30 @@ async function updateResummarizeHint(settings) {
   if (!resummarizeHint) return;
   const s = settings || (await getSettings());
   const target = s.summaryLanguage;
-  const stale =
+  const languageStale =
     !!currentSummaryText.trim() &&
     currentSummaryLanguage != null &&
     currentSummaryLanguage !== target;
-  if (!stale) {
+  const engineStale =
+    !!currentSummaryText.trim() &&
+    currentTranslationEngine != null &&
+    currentTranslationEngine !== s.translationEngine;
+  if (!languageStale && !engineStale) {
     resummarizeHint.classList.add("hidden");
     return;
   }
-  resummarizeHintText.textContent =
-    target === "auto"
-      ? "This summary isn't in the page's original language. Re-summarize to apply."
-      : `This summary isn't in ${LANGUAGE_LABELS.get(target) || target}. Re-summarize to apply.`;
+  if (languageStale && engineStale) {
+    resummarizeHintText.textContent =
+      "The summary language and translation engine changed. Re-summarize to apply.";
+  } else if (engineStale) {
+    resummarizeHintText.textContent =
+      "This summary used a different translation engine. Re-summarize to apply.";
+  } else {
+    resummarizeHintText.textContent =
+      target === "auto"
+        ? "This summary isn't in the page's original language. Re-summarize to apply."
+        : `This summary isn't in ${LANGUAGE_LABELS.get(target) || target}. Re-summarize to apply.`;
+  }
   resummarizeHint.classList.remove("hidden");
 }
 
@@ -1218,6 +1231,8 @@ async function consumeSummaryStream(stream, { tab, promptsCacheKey }) {
       durationSeconds: currentPageData?.durationSeconds,
       content: currentPageData?.content,
     }),
+    summaryLanguage: currentSummaryLanguage,
+    translationEngine: currentTranslationEngine,
   });
   setSuggestedQuestionsLoading();
 
@@ -1256,6 +1271,7 @@ async function summarizeActivePage() {
     const provider = getProvider(settings);
     const model = getModelForSettings(settings);
     currentSummaryLanguage = settings.summaryLanguage;
+    currentTranslationEngine = settings.translationEngine;
     const pageData = await extractFromActiveTab(tab);
 
     if (!pageData) {
@@ -1286,6 +1302,7 @@ async function summarizeActivePage() {
       model,
       settings.summaryLanguage,
       settings.customInstructions,
+      settings.translationEngine,
     );
     const promptsCacheKey = await getPromptsCacheKey(
       tab.url,
@@ -1293,6 +1310,7 @@ async function summarizeActivePage() {
       model,
       settings.summaryLanguage,
       settings.customInstructions,
+      settings.translationEngine,
     );
     const finalize = {
       cacheKey,
@@ -1361,6 +1379,8 @@ async function summarizeActivePage() {
       url: tab.url,
       streamId,
       promptsCacheKey,
+      summaryLanguage: settings.summaryLanguage,
+      translationEngine: settings.translationEngine,
     });
     showCancelSummarizeButton(streamId);
 
@@ -1598,6 +1618,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     const state = await loadViewState(tab.id);
 
     if (state && state.urlHash === (await hashUrl(tab.url)) && state.streamId) {
+      currentSummaryLanguage =
+        state.summaryLanguage ?? settings.summaryLanguage;
+      currentTranslationEngine =
+        state.translationEngine ?? settings.translationEngine;
       if (state.subview === "summarizing") {
         showOnlyView("summaryView");
         showSummarizingContext();
@@ -1676,7 +1700,10 @@ document.addEventListener("DOMContentLoaded", async () => {
         }
         if (state.subview === "summary" && state.summaryText) {
           currentSummaryText = state.summaryText;
-          currentSummaryLanguage = settings.summaryLanguage;
+          currentSummaryLanguage =
+            state.summaryLanguage ?? settings.summaryLanguage;
+          currentTranslationEngine =
+            state.translationEngine ?? settings.translationEngine;
           summaryText.innerHTML = renderMarkdown(state.summaryText);
           makeSummaryPassagesFocusable();
           setSummaryCopyButtonsVisible(!!state.summaryText.trim());
@@ -1715,6 +1742,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       model,
       settings.summaryLanguage,
       settings.customInstructions,
+      settings.translationEngine,
     );
     const promptsCacheKey = await getPromptsCacheKey(
       tab.url,
@@ -1722,12 +1750,14 @@ document.addEventListener("DOMContentLoaded", async () => {
       model,
       settings.summaryLanguage,
       settings.customInstructions,
+      settings.translationEngine,
     );
     const cached = await chrome.storage.local.get([cacheKey, promptsCacheKey]);
 
     if (cached[cacheKey]) {
       currentSummaryText = cached[cacheKey];
       currentSummaryLanguage = settings.summaryLanguage;
+      currentTranslationEngine = settings.translationEngine;
       summaryText.innerHTML = renderMarkdown(cached[cacheKey]);
       makeSummaryPassagesFocusable();
       setSummaryCopyButtonsVisible(!!cached[cacheKey].trim());
@@ -1898,7 +1928,8 @@ summaryLanguageSelect?.addEventListener("change", async () => {
 
 translationEngineRadios.forEach((radio) => {
   radio.addEventListener("change", async () => {
-    await saveSettings({ translationEngine: radio.value });
+    const settings = await saveSettings({ translationEngine: radio.value });
+    await updateResummarizeHint(settings);
   });
 });
 
@@ -2013,6 +2044,7 @@ async function clearCachedData() {
   const viewStates = await clearAllViewStates();
   currentSummaryText = "";
   currentSummaryLanguage = null;
+  currentTranslationEngine = null;
   updateResummarizeHint();
   await loadPastSummaries();
   return pages + viewStates;

--- a/apogee-extension/tests/storage/pageCache.test.js
+++ b/apogee-extension/tests/storage/pageCache.test.js
@@ -68,21 +68,35 @@ test("cache key helpers embed the hashed url and are namespaced by kind", async 
   const hash = await hashUrl(url);
   assert.strictEqual(
     await getSummaryCacheKey(url, "bullets", "model-x"),
-    `summary:bullets:auto:model-x:${hash}`,
+    `summary:bullets:auto:model-x:opus:${hash}`,
   );
   assert.strictEqual(
     await getSummaryCacheKey(url, "bullets", "model-x", "es"),
-    `summary:bullets:es:model-x:${hash}`,
+    `summary:bullets:es:model-x:opus:${hash}`,
   );
   assert.strictEqual(
     await getPromptsCacheKey(url, "bullets", "model-x"),
-    `suggested-prompts:bullets:auto:model-x:${hash}`,
+    `suggested-prompts:bullets:auto:model-x:opus:${hash}`,
   );
   assert.strictEqual(
     await getPromptsCacheKey(url, "bullets", "model-x", "es"),
-    `suggested-prompts:bullets:es:model-x:${hash}`,
+    `suggested-prompts:bullets:es:model-x:opus:${hash}`,
   );
   assert.strictEqual(await getContentCacheKey(url), `content:${hash}`);
+});
+
+test("cache keys change with the translation engine that shaped the output", async () => {
+  const args = ["https://example.com/article", "bullets", "model-x", "bg", ""];
+
+  const llmSummary = await getSummaryCacheKey(...args, "llm");
+  const opusSummary = await getSummaryCacheKey(...args, "opus");
+  const llmPrompts = await getPromptsCacheKey(...args, "llm");
+  const opusPrompts = await getPromptsCacheKey(...args, "opus");
+
+  assert.notStrictEqual(llmSummary, opusSummary);
+  assert.notStrictEqual(llmPrompts, opusPrompts);
+  assert.match(llmSummary, /:llm:/);
+  assert.match(opusSummary, /:opus:/);
 });
 
 test("cache keys change with the custom instructions that shaped the prompt", async () => {
@@ -128,18 +142,18 @@ test("cache keys change with the custom instructions that shaped the prompt", as
   );
 });
 
-test("empty or whitespace-only instructions keep the pre-existing key shape", async () => {
+test("empty or whitespace-only instructions omit the instructions suffix", async () => {
   const url = "https://example.com/article";
   const hash = await hashUrl(url);
 
   for (const instructions of [undefined, "", "   \n  "]) {
     assert.strictEqual(
       await getSummaryCacheKey(url, "bullets", "model-x", "auto", instructions),
-      `summary:bullets:auto:model-x:${hash}`,
+      `summary:bullets:auto:model-x:opus:${hash}`,
     );
     assert.strictEqual(
       await getPromptsCacheKey(url, "bullets", "model-x", "auto", instructions),
-      `suggested-prompts:bullets:auto:model-x:${hash}`,
+      `suggested-prompts:bullets:auto:model-x:opus:${hash}`,
     );
   }
 });


### PR DESCRIPTION
## Summary

- include the translation engine in summary and suggested-prompt cache keys
- pass the selected engine through the local Ollama suggested-question path
- persist the engine with popup view state and show the existing re-summarize hint when it changes
- add a regression test proving llm and opus keys do not collide

Legacy cache entries are intentionally not reused because they do not identify which translation engine shaped their output. They remain available in history until normal eviction or a cache clear.

Follow-up to #89.

## Validation

- npm run format:check
- npm run lint
- npm test (252 passed)
- npm run build (Chrome and Firefox)