### PR TITLE
feat(ux): add keyboard shortcut to open extension popup

### DIFF
--- a/apogee-extension/manifest.json
+++ b/apogee-extension/manifest.json
@@ -37,6 +37,12 @@
         "mac": "Alt+Shift+U"
       },
       "description": "Summarize the active page"
+    },
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Alt+Shift+A",
+        "mac": "Alt+Shift+A"
+      }
     }
   },
   "content_security_policy": {


### PR DESCRIPTION
Add Chrome's reserved _execute_action command with a suggested Alt+Shift+A binding so users can open the Apogee popup via keyboard instead of clicking the toolbar icon.

Closes #96

## Summary

<!-- What does this PR change, and why? -->

## Test plan

<!-- How did you verify this? Check the boxes you actually ran. -->

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [x] Manually exercised the change in a loaded browser extension

## Privacy impact

<!-- Does this add, remove, or change any outbound network request or permission? -->

- [x] No new outbound network calls
- [x] Adds/changes a network call (described above, docs updated)

<!-- Permissions and network behaviour are described in four places that must
     agree: apogee-extension/manifest.json, README.md (Privacy & Permissions),
     PRIVACY.md, and store-listing.md (permission justifications). A claim in
     one and not the others is what store reviewers catch. -->

- [x] Permissions unchanged, or all four of manifest / README / PRIVACY /
      store-listing updated together
