### PR TITLE
test: add timestamp helper coverage

### DIFF
--- a/apogee-extension/tests/summarize/timestamps.test.js
+++ b/apogee-extension/tests/summarize/timestamps.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert";
+import {
+  timestampToSeconds,
+  formatSecondsAsTimestamp,
+} from "../../lib/summarize/timestamps.js";
+
+test("timestampToSeconds converts timestamps to second offsets", () => {
+  assert.strictEqual(timestampToSeconds("1:23:45"), 5025);
+  assert.strictEqual(timestampToSeconds("4:20"), 260);
+  assert.strictEqual(timestampToSeconds("0:00"), 0);
+});
+
+test("formatSecondsAsTimestamp formats offsets with and without hours", () => {
+  assert.strictEqual(formatSecondsAsTimestamp(5025), "1:23:45");
+  assert.strictEqual(formatSecondsAsTimestamp(260), "4:20");
+  assert.strictEqual(formatSecondsAsTimestamp(0), "0:00");
+});
+
+test("timestamp helpers preserve canonical timestamps through a round trip", () => {
+  for (const timestamp of ["0:00", "4:20", "1:23:45"]) {
+    assert.strictEqual(
+      formatSecondsAsTimestamp(timestampToSeconds(timestamp)),
+      timestamp,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- add unit coverage for `timestampToSeconds`
- cover timestamp formatting with and without hours
- verify canonical timestamps round-trip through both helpers

## Verification

- `node --test tests/summarize/timestamps.test.js`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #95
