### PR TITLE
fix(resume): restore completed summaries after stream expiry

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -41,7 +41,11 @@ import {
   getModelForSettings,
 } from "../lib/engines/providers.js";
 import { PROVIDERS, TRANSLATION_ENGINES } from "../lib/constants.js";
-import { saveViewState, removeViewState } from "../lib/storage/viewState.js";
+import {
+  saveViewState,
+  saveViewStateIfJobMatches,
+  removeViewState,
+} from "../lib/storage/viewState.js";
 
 initDebugLogging();
 
@@ -128,6 +132,21 @@ async function ensureOffscreenDocumentOnce() {
 
 function nextStreamId(kind) {
   return `${kind}-${crypto.randomUUID()}`;
+}
+async function recordPopupSummaryStream(payload, streamId) {
+  const finalize = payload?.finalize;
+  if (!finalize?.jobId || finalize.tabId == null) return;
+  await saveViewStateIfJobMatches(
+    finalize.tabId,
+    finalize.jobId,
+    {
+      streamId,
+      promptsCacheKey: finalize.promptsCacheKey,
+      summaryLanguage: finalize.language,
+      translationEngine: finalize.translationEngine,
+    },
+    "summarizing",
+  );
 }
 
 function isOffscreenStream(streamId) {
@@ -617,6 +636,7 @@ async function runBackgroundSummarize(
     }
   }
 
+  const jobId = `summary-${crypto.randomUUID()}`;
   const finalize = {
     cacheKey: await getSummaryCacheKey(
       cacheUrl,
@@ -644,6 +664,7 @@ async function runBackgroundSummarize(
     translationEngine: settings.translationEngine,
     sensitive: await isPrivateUrl(tab.url, settings),
     tabId: tab.id,
+    jobId,
     windowId: tab.windowId,
   };
 
@@ -664,13 +685,31 @@ async function runBackgroundSummarize(
   let streamId;
   if (providerType === PROVIDERS.LOCAL) {
     streamId = nextStreamId("ollama");
-    startOllamaStream(streamId, { ...common, host: settings.ollamaHost });
   } else if (providerType === PROVIDERS.TRANSFORMERS) {
     streamId = nextStreamId("transformers");
-    startTransformersStream(streamId, common);
   } else {
     await ensureOffscreenDocument();
     streamId = nextStreamId("webllm");
+  }
+
+  await saveViewState(tab.id, {
+    view: "summaryView",
+    subview: "summarizing",
+    url: tab.url,
+    streamId,
+    jobId,
+    summaryText: "",
+    timeSaved: null,
+    promptsCacheKey: finalize.promptsCacheKey,
+    summaryLanguage: settings.summaryLanguage,
+    translationEngine: settings.translationEngine,
+  });
+
+  if (providerType === PROVIDERS.LOCAL) {
+    startOllamaStream(streamId, { ...common, host: settings.ollamaHost });
+  } else if (providerType === PROVIDERS.TRANSFORMERS) {
+    startTransformersStream(streamId, common);
+  } else {
     const resp = await chrome.runtime.sendMessage({
       target: "offscreen",
       action: "summarize",
@@ -679,16 +718,6 @@ async function runBackgroundSummarize(
     });
     if (resp?.error) throw new Error(resp.error);
   }
-
-  await saveViewState(tab.id, {
-    view: "summaryView",
-    subview: "summarizing",
-    url: tab.url,
-    streamId,
-    promptsCacheKey: finalize.promptsCacheKey,
-    summaryLanguage: settings.summaryLanguage,
-    translationEngine: settings.translationEngine,
-  });
 }
 
 function notifyJobFailed(err) {
@@ -983,6 +1012,7 @@ async function finalizeSummaryJob({ finalize, model, title, url, text }) {
     notifyOnFinish,
     sensitive,
     tabId,
+    jobId,
     windowId,
     language,
     translationEngine,
@@ -1001,17 +1031,22 @@ async function finalizeSummaryJob({ finalize, model, title, url, text }) {
       title,
     ));
 
-  if (!persisted && isSelection) {
-    await saveViewState(tabId, {
-      view: "summaryView",
-      subview: "summary",
-      url,
-      streamId: null,
-      summaryText: text,
-      promptsCacheKey,
-      summaryLanguage: language,
-      translationEngine,
-    });
+  if (persisted || isSelection) {
+    await saveViewStateIfJobMatches(
+      tabId,
+      jobId,
+      {
+        view: "summaryView",
+        subview: "summary",
+        url: persistUrl || url,
+        streamId: null,
+        summaryText: text,
+        promptsCacheKey,
+        summaryLanguage: language,
+        translationEngine,
+      },
+      "summarizing",
+    );
   }
   runSuggestQuestionsJob({
     promptsCacheKey,
@@ -1253,6 +1288,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           await ensureOffscreenDocument();
 
           const streamId = nextStreamId("webllm");
+          await recordPopupSummaryStream(message.payload, streamId);
 
           const { customInstructions } = await getSettings();
           const resp = await chrome.runtime.sendMessage({
@@ -1269,6 +1305,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         case "ollama-stream": {
           const streamId = nextStreamId("ollama");
+          await recordPopupSummaryStream(message.payload, streamId);
           startOllamaStream(streamId, message.payload);
           sendResponse({ streamId });
           break;
@@ -1315,6 +1352,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         case "transformers-stream": {
           const streamId = nextStreamId("transformers");
+          await recordPopupSummaryStream(message.payload, streamId);
           if (hasOffscreenAPI) {
             await ensureOffscreenDocument();
             const { action, ...jobPayload } = message.payload;

--- a/apogee-extension/lib/storage/viewState.js
+++ b/apogee-extension/lib/storage/viewState.js
@@ -9,17 +9,23 @@ const MAX_VIEW_STATES = 50;
 
 const acquireViewStateLock = createLock();
 
-export async function saveViewState(tabId, partial) {
-  if (tabId == null) return null;
+async function preparePartial(partial) {
   let scrubContent = false;
   if (partial.url) {
-    scrubContent = !(await shouldPersist(partial.url));
+    const url = partial.url;
+    scrubContent = !(await shouldPersist(url));
     partial = {
       ...partial,
       url: undefined,
-      urlHash: await hashUrl(partial.url),
+      urlHash: await hashUrl(url),
     };
   }
+  return { partial, scrubContent };
+}
+
+async function writeViewState(tabId, partial, expectedJob = null) {
+  if (tabId == null) return null;
+  const prepared = await preparePartial(partial);
   const release = await acquireViewStateLock();
   try {
     const key = viewStateKey(tabId);
@@ -27,8 +33,16 @@ export async function saveViewState(tabId, partial) {
       key,
       "viewStateOrder",
     ]);
-    const state = { ...(rest[key] || {}), ...partial };
-    if (scrubContent) {
+    const current = rest[key] || {};
+    if (
+      expectedJob &&
+      (current.jobId !== expectedJob.jobId ||
+        (expectedJob.subview && current.subview !== expectedJob.subview))
+    ) {
+      return null;
+    }
+    const state = { ...current, ...prepared.partial };
+    if (prepared.scrubContent) {
       delete state.question;
       delete state.answerText;
       delete state.summaryText;
@@ -47,6 +61,20 @@ export async function saveViewState(tabId, partial) {
   } finally {
     release();
   }
+}
+
+export function saveViewState(tabId, partial) {
+  return writeViewState(tabId, partial);
+}
+
+export function saveViewStateIfJobMatches(
+  tabId,
+  jobId,
+  partial,
+  subview = null,
+) {
+  if (!jobId) return Promise.resolve(null);
+  return writeViewState(tabId, partial, { jobId, subview });
 }
 
 export async function loadViewState(tabId) {

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -41,6 +41,7 @@ import {
 } from "../lib/util/readingTime.js";
 import {
   saveViewState,
+  saveViewStateIfJobMatches,
   loadViewState,
   clearAllViewStates,
   isViewStateKey,
@@ -1115,9 +1116,22 @@ function renderSummaryError(error) {
   renderError(summaryText, toUserMessage(error));
 }
 
-function returnHomeAfterCancel(tabId) {
+async function returnHomeAfterCancel(tabId, jobId = null) {
+  const state = jobId
+    ? await saveViewStateIfJobMatches(
+        tabId,
+        jobId,
+        { view: "homeView", subview: null, streamId: null, jobId: null },
+        "summarizing",
+      )
+    : await saveViewState(tabId, {
+        view: "homeView",
+        subview: null,
+        streamId: null,
+        jobId: null,
+      });
+  if (!state) return;
   showOnlyView("homeView");
-  saveViewState(tabId, { view: "homeView", streamId: null });
 }
 
 function showSummaryContext(questions = []) {
@@ -1212,7 +1226,7 @@ async function streamGeneratorIntoElement(generator, element) {
   return fullText;
 }
 
-async function consumeSummaryStream(stream, { tab, promptsCacheKey }) {
+async function consumeSummaryStream(stream, { tab, promptsCacheKey, jobId }) {
   const text = await streamGeneratorIntoElement(stream, summaryText);
 
   currentSummaryText = text;
@@ -1221,11 +1235,12 @@ async function consumeSummaryStream(stream, { tab, promptsCacheKey }) {
   setSummaryCopyButtonsVisible(!!text.trim());
   updateResummarizeHint();
   updateTimeSavedBadge(currentPageData, text);
-  await saveViewState(tab.id, {
+  const completedState = {
     view: "summaryView",
     subview: "summary",
     url: tab.url,
     streamId: null,
+    summaryText: text,
     timeSaved: timeSavedInputsFor({
       type: currentPageData?.type,
       durationSeconds: currentPageData?.durationSeconds,
@@ -1233,7 +1248,17 @@ async function consumeSummaryStream(stream, { tab, promptsCacheKey }) {
     }),
     summaryLanguage: currentSummaryLanguage,
     translationEngine: currentTranslationEngine,
-  });
+  };
+  if (jobId) {
+    await saveViewStateIfJobMatches(
+      tab.id,
+      jobId,
+      completedState,
+      "summarizing",
+    );
+  } else {
+    await saveViewState(tab.id, completedState);
+  }
   setSuggestedQuestionsLoading();
 
   currentPromptsCacheKey = promptsCacheKey;
@@ -1256,6 +1281,7 @@ async function summarizeActivePage() {
   showSummarizingContext();
   setLoadingIndicator(summaryText, randomSummarizeVerb());
 
+  const jobId = `summary-${crypto.randomUUID()}`;
   try {
     const [tab] = await chrome.tabs.query({
       active: true,
@@ -1266,6 +1292,10 @@ async function summarizeActivePage() {
       subview: "summarizing",
       url: tab.url,
       streamId: null,
+      jobId,
+      summaryText: "",
+      timeSaved: null,
+      promptsCacheKey: null,
     });
     const settings = await getSettings();
     const provider = getProvider(settings);
@@ -1322,6 +1352,8 @@ async function summarizeActivePage() {
       notifyOnFinish: false,
       language: settings.summaryLanguage,
       translationEngine: settings.translationEngine,
+      jobId,
+      tabId: tab.id,
     };
 
     let streamId, stream;
@@ -1373,22 +1405,34 @@ async function summarizeActivePage() {
       }));
     }
 
-    await saveViewState(tab.id, {
-      view: "summaryView",
-      subview: "summarizing",
-      url: tab.url,
-      streamId,
-      promptsCacheKey,
-      summaryLanguage: settings.summaryLanguage,
-      translationEngine: settings.translationEngine,
-    });
+    const activeJobState = await saveViewStateIfJobMatches(
+      tab.id,
+      jobId,
+      {
+        view: "summaryView",
+        subview: "summarizing",
+        url: tab.url,
+        streamId,
+        promptsCacheKey,
+        summaryLanguage: settings.summaryLanguage,
+        translationEngine: settings.translationEngine,
+      },
+      "summarizing",
+    );
+    if (!activeJobState) {
+      const latestState = await loadViewState(tab.id);
+      if (latestState?.jobId !== jobId) {
+        cancelStream(streamId);
+        return;
+      }
+    }
     showCancelSummarizeButton(streamId);
 
-    await consumeSummaryStream(stream, { tab, promptsCacheKey });
+    await consumeSummaryStream(stream, { tab, promptsCacheKey, jobId });
     announce("Summary ready.");
   } catch (error) {
     if (error instanceof StreamCancelledError) {
-      returnHomeAfterCancel(activeTabId);
+      await returnHomeAfterCancel(activeTabId, jobId);
     } else {
       renderSummaryError(error);
     }
@@ -1615,7 +1659,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     activeTabId = tab.id;
     setLinkifyOriginFromUrl(tab.url);
 
-    const state = await loadViewState(tab.id);
+    let state = await loadViewState(tab.id);
 
     if (state && state.urlHash === (await hashUrl(tab.url)) && state.streamId) {
       currentSummaryLanguage =
@@ -1627,23 +1671,46 @@ document.addEventListener("DOMContentLoaded", async () => {
         showSummarizingContext();
         setLoadingIndicator(summaryText, randomSummarizeVerb());
         showCancelSummarizeButton(state.streamId);
+        let resumeFromCompletedState = false;
         try {
           await getPageData(tab);
           await consumeSummaryStream(attachToStream(state.streamId), {
             tab,
             promptsCacheKey: state.promptsCacheKey,
+            jobId: state.jobId,
           });
         } catch (error) {
           if (error instanceof StreamCancelledError) {
-            returnHomeAfterCancel(tab.id);
+            await returnHomeAfterCancel(tab.id, state.jobId);
           } else {
-            renderSummaryError(error);
-            await saveViewState(tab.id, { streamId: null });
+            const completedState = await loadViewState(tab.id);
+            if (
+              state.jobId &&
+              completedState?.jobId === state.jobId &&
+              completedState.subview === "summary" &&
+              !completedState.streamId &&
+              completedState.summaryText
+            ) {
+              state = completedState;
+              resumeFromCompletedState = true;
+            } else {
+              renderSummaryError(error);
+              if (state.jobId) {
+                await saveViewStateIfJobMatches(
+                  tab.id,
+                  state.jobId,
+                  { streamId: null },
+                  "summarizing",
+                );
+              } else {
+                await saveViewState(tab.id, { streamId: null });
+              }
+            }
           }
         } finally {
           hideCancelSummarizeButton();
         }
-        return;
+        if (!resumeFromCompletedState) return;
       }
 
       if (state.subview === "answer") {

--- a/apogee-extension/tests/storage/viewState.test.js
+++ b/apogee-extension/tests/storage/viewState.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert";
 
 import {
   saveViewState,
+  saveViewStateIfJobMatches,
   loadViewState,
   clearAllViewStates,
 } from "../../lib/storage/viewState.js";
@@ -122,4 +123,99 @@ test("view state stores a hash of the url, never the url itself", async () => {
   assert.strictEqual(stored.url, undefined);
   assert.strictEqual(stored.urlHash, await hashUrl(url));
   assert.ok(!JSON.stringify(data).includes("hunter2"));
+});
+
+test("matching job finalization survives a completion before stream setup", async () => {
+  installFakeStorage({ settings: { saveHistory: true } });
+  const url = "https://example.com/article";
+
+  await saveViewState(7, {
+    view: "summaryView",
+    subview: "summarizing",
+    url,
+    jobId: "job-fast",
+    streamId: null,
+  });
+
+  const completed = await saveViewStateIfJobMatches(
+    7,
+    "job-fast",
+    {
+      view: "summaryView",
+      subview: "summary",
+      url,
+      streamId: null,
+      summaryText: "The completed result.",
+    },
+    "summarizing",
+  );
+  const lateStreamWrite = await saveViewStateIfJobMatches(
+    7,
+    "job-fast",
+    { subview: "summarizing", streamId: "stream-too-late" },
+    "summarizing",
+  );
+
+  assert.strictEqual(completed.subview, "summary");
+  assert.strictEqual(lateStreamWrite, null);
+  assert.deepStrictEqual(await loadViewState(7), completed);
+});
+
+test("an older job cannot replace a newer job with the same cache key", async () => {
+  installFakeStorage({ settings: { saveHistory: true } });
+  const url = "https://example.com/article";
+  const cacheKey = "summary:same-settings";
+
+  await saveViewState(7, {
+    view: "summaryView",
+    subview: "summarizing",
+    url,
+    jobId: "job-old",
+    streamId: "stream-old",
+    cacheKey,
+  });
+  await saveViewState(7, {
+    view: "summaryView",
+    subview: "summarizing",
+    url,
+    jobId: "job-new",
+    streamId: "stream-new",
+    summaryText: "",
+    cacheKey,
+  });
+
+  const staleCompletion = await saveViewStateIfJobMatches(
+    7,
+    "job-old",
+    {
+      subview: "summary",
+      streamId: null,
+      summaryText: "Stale result",
+    },
+    "summarizing",
+  );
+
+  assert.strictEqual(staleCompletion, null);
+  assert.deepStrictEqual(await loadViewState(7), {
+    view: "summaryView",
+    subview: "summarizing",
+    url: undefined,
+    urlHash: await hashUrl(url),
+    jobId: "job-new",
+    streamId: "stream-new",
+    summaryText: "",
+    cacheKey,
+  });
+
+  const currentCompletion = await saveViewStateIfJobMatches(
+    7,
+    "job-new",
+    {
+      subview: "summary",
+      streamId: null,
+      summaryText: "Current result",
+    },
+    "summarizing",
+  );
+  assert.strictEqual(currentCompletion.summaryText, "Current result");
 });


### PR DESCRIPTION
## Summary

- assign each summary generation a unique job ID before a provider can complete
- atomically transition only the matching summarizing view state to the exact completed result
- keep Ollama, Transformers.js, and offscreen/WebLLM stream setup aligned
- recover a completed same-job result when the transport stream has already expired
- prevent late completions and late stream writes from replacing a newer job on the same tab

The reproduction is confirmed on starting main `26485bbb649d3d4f3bf0bb24d99d7e56d0c95f65`: a persisted summary leaves the popup state as `summarizing`; after stream cleanup, the first reopen returns from the failed attach path before reaching the cached result.

Private hosts and history-off behavior remain unchanged: terminal summary text is only retained when the existing persistence rules allow it (or for the existing selection case).

## Tests

- add view-state regression coverage for completion before stream setup
- add stale-job protection coverage for consecutive jobs sharing a cache key
- `npm run format:check`
- `npm run lint`
- `npm test` (254 passed)
- `npm run build` (Chrome and Firefox)

Fixes #110
