### PR TITLE
feat(extractors): add Stack Overflow question extractor

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,7 +55,7 @@ Apogee extension codebase lives in `apogee-extension/`. Below is a breakdown of 
 
 ### 1. `content/` (Tab Context Extractor Scripts)
 
-- **What it Contains**: Scripts injected directly into active browser tabs when you trigger summarization or Q&A. Includes `content.js` (main injection script), `Readability.js` (bundled article parser from Mozilla themselves), and specialized site extractors in `content/extractors/` such as `youtube.js`, `bilibili.js`, `wikipedia.js`, `reddit.js`, `gmail.js`, `hackerNews.js`, `github.js`, `lobsters.js`, `arxiv.js`, `mastodon.js`, and `plainArticle.js`.
+- **What it Contains**: Scripts injected directly into active browser tabs when you trigger summarization or Q&A. Includes `content.js` (main injection script), `Readability.js` (bundled article parser from Mozilla themselves), and specialized site extractors in `content/extractors/` such as `youtube.js`, `bilibili.js`, `wikipedia.js`, `reddit.js`, `gmail.js`, `hackerNews.js`, `github.js`, `lobsters.js`, `arxiv.js`, `mastodon.js`, `stackoverflow.js`, and `plainArticle.js`.
 - **How to Contribute**: Create a new extractor file in `content/extractors/` that reads DOM nodes cleanly without mutating global window scope. Register your extractor in `lib/extract/pageExtraction.js`, create a static HTML test fixture in `tests/extractors/fixtures/`, and add unit test cases in `tests/extractors/`.
 
 ### 2. `lib/` (Core Application Libraries)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,8 +7,8 @@ This document outlines current work, upcoming priorities, and long-term goals fo
 ## Now
 
 - **Extractor Expansion**:
-  - Add page extractors for more platforms (Stack Overflow, Lemmy, Discourse, GitLab, Dev.to, Bluesky).
-  - Shipped extractors: YouTube, Bilibili, Wikipedia, Gmail, Reddit, Hacker News, GitHub, Lobsters, arXiv, Mastodon.
+  - Add page extractors for more platforms (Lemmy, Discourse, GitLab, Dev.to, Bluesky).
+  - Shipped extractors: YouTube, Bilibili, Wikipedia, Gmail, Reddit, Hacker News, GitHub, Lobsters, arXiv, Mastodon, Stack Overflow.
   - Keep extractor creation simple so contributors can write unit-tested extractors in Node without running a browser.
 - **Test Coverage**:
   - Expand test suites for existing extractors (Bilibili) and untested library modules (diagnostics, hash, timestamps, mapReduce, viewState).

--- a/apogee-extension/content/content.js
+++ b/apogee-extension/content/content.js
@@ -58,6 +58,9 @@ async function extractPageContent() {
     if (data) return { ...data, isPdf: false };
   }
 
+  const stackOverflowData = extractStackOverflow();
+  if (stackOverflowData) return { ...stackOverflowData, isPdf: false };
+
   const mastodonData = extractMastodon();
   if (mastodonData) return { ...mastodonData, isPdf: false };
 

--- a/apogee-extension/content/extractors/stackoverflow.js
+++ b/apogee-extension/content/extractors/stackoverflow.js
@@ -1,0 +1,179 @@
+const SO_MAX_ANSWERS = 8;
+const SO_MAX_QUESTION_COMMENTS = 8;
+const SO_MAX_COMMENTS_PER_ANSWER = 5;
+const SO_MAX_ANSWER_CHARS = 4000;
+const SO_MAX_COMMENT_CHARS = 500;
+
+const STACKEXCHANGE_HOSTS = [
+  "stackoverflow.com",
+  "stackexchange.com",
+  "superuser.com",
+  "serverfault.com",
+  "askubuntu.com",
+  "mathoverflow.net",
+  "stackapps.com",
+];
+
+function soText(el) {
+  if (!el) return "";
+  return (el.innerText || el.textContent || "").trim();
+}
+
+function isStackExchangeHost() {
+  const host = location.hostname.toLowerCase();
+  return STACKEXCHANGE_HOSTS.some(
+    (domain) => host === domain || host.endsWith(`.${domain}`),
+  );
+}
+
+function isStackExchangeQuestionPage() {
+  if (!isStackExchangeHost()) return false;
+  if (!/^\/questions\/\d+/.test(location.pathname)) return false;
+  return Boolean(document.querySelector("#question, .question"));
+}
+
+function soScore(root) {
+  const vote = root.querySelector(".js-vote-count");
+  if (!vote) return undefined;
+  const attr = vote.getAttribute("data-value");
+  if (attr !== null && attr !== "") {
+    const n = parseInt(attr, 10);
+    if (!isNaN(n)) return n;
+  }
+  const n = parseInt(soText(vote), 10);
+  return isNaN(n) ? undefined : n;
+}
+
+function soAuthor(root) {
+  const el =
+    root.querySelector(".post-signature.owner .user-details a") ||
+    root.querySelector(".user-details a");
+  return soText(el) || "anon";
+}
+
+function soBody(root) {
+  const el =
+    root.querySelector(".js-post-body") ||
+    root.querySelector(".s-prose") ||
+    root.querySelector(".post-text");
+  return soText(el);
+}
+
+function soIsAccepted(answerEl) {
+  return (
+    answerEl.classList.contains("accepted-answer") ||
+    answerEl.getAttribute("itemprop") === "acceptedAnswer"
+  );
+}
+
+function soComments(root) {
+  return Array.from(root.querySelectorAll("li.comment, .comment")).map(
+    (el) => ({
+      author: soText(el.querySelector(".comment-user")) || "anon",
+      text: threadTruncate(
+        soText(el.querySelector(".comment-copy")),
+        SO_MAX_COMMENT_CHARS,
+      ),
+    }),
+  );
+}
+
+function soSelectAnswers(answers) {
+  const withText = answers.filter((a) => a.text);
+  const accepted = withText.filter((a) => a.accepted);
+  const rest = withText
+    .filter((a) => !a.accepted)
+    .sort((a, b) => (b.score ?? -Infinity) - (a.score ?? -Infinity));
+  return [...accepted, ...rest].slice(0, SO_MAX_ANSWERS);
+}
+
+function extractStackOverflow() {
+  if (!isStackExchangeQuestionPage()) return null;
+
+  const questionEl =
+    document.querySelector("#question") || document.querySelector(".question");
+  if (!questionEl) return null;
+
+  const titleEl =
+    document.querySelector("#question-header h1 a") ||
+    document.querySelector("h1 a.question-hyperlink") ||
+    document.querySelector("a.question-hyperlink");
+  const title = (soText(titleEl) || document.title).trim();
+  const questionText = soBody(questionEl);
+  if (!title || !questionText) return null;
+
+  const tags = Array.from(
+    questionEl.querySelectorAll(".post-taglist a.post-tag, a.post-tag"),
+  )
+    .map((t) => soText(t))
+    .filter(Boolean);
+  const score = soScore(questionEl);
+  const author = soAuthor(questionEl);
+  const questionComments = soComments(questionEl)
+    .filter((c) => c.text)
+    .slice(0, SO_MAX_QUESTION_COMMENTS);
+
+  const answers = soSelectAnswers(
+    Array.from(document.querySelectorAll("#answers .answer, .answer")).map(
+      (el) => ({
+        author: soAuthor(el),
+        text: threadTruncate(soBody(el), SO_MAX_ANSWER_CHARS),
+        score: soScore(el),
+        accepted: soIsAccepted(el),
+        comments: soComments(el)
+          .filter((c) => c.text)
+          .slice(0, SO_MAX_COMMENTS_PER_ANSWER),
+      }),
+    ),
+  );
+
+  const items = [];
+  for (const answer of answers) {
+    items.push({
+      depth: 0,
+      author: answer.author,
+      text: answer.text,
+      score: answer.score,
+      accepted: answer.accepted,
+    });
+    for (const comment of answer.comments) {
+      items.push({
+        depth: 1,
+        author: comment.author,
+        text: comment.text,
+      });
+    }
+  }
+
+  const nodes = buildThreadNodes(items);
+  const formatted = selectThreadComments(nodes, (n) => n.text, items.length);
+
+  let content = `Stack Overflow question\n\nTitle: ${title}\n`;
+  if (tags.length) content += `Tags: ${tags.join(", ")}\n`;
+  const meta = [
+    typeof score === "number" && `score ${score}`,
+    author && `by ${author}`,
+  ]
+    .filter(Boolean)
+    .join(" | ");
+  if (meta) content += `${meta}\n`;
+  content += `\nPost:\n${questionText}\n`;
+
+  if (questionComments.length) {
+    content += `\nQuestion comments:\n`;
+    for (const c of questionComments) {
+      content += `- ${c.author}: ${c.text}\n`;
+    }
+  }
+
+  content += formatted.length
+    ? `\n${THREAD_COMMENTS_HEADER}\n${formatThreadComments(formatted)}\n`
+    : `\n(No comments yet.)\n`;
+
+  return {
+    type: "stackoverflow",
+    title,
+    url: location.href,
+    content: content.trim(),
+  };
+}

--- a/apogee-extension/content/extractors/thread.js
+++ b/apogee-extension/content/extractors/thread.js
@@ -59,6 +59,7 @@ function formatThreadComments(nodes) {
     if (n.directReplies) line += ` <replies: ${n.directReplies}>`;
     if (n.downvotes) line += ` {downvotes: ${n.downvotes}}`;
     if (typeof n.score === "number") line += ` (score: ${n.score})`;
+    if (n.accepted) line += ` [accepted]`;
     line += ` ${n.author}: ${n.text}`;
     lines.push(line);
   }

--- a/apogee-extension/eslint.config.js
+++ b/apogee-extension/eslint.config.js
@@ -54,6 +54,7 @@ export default [
         extractWikipedia: "readonly",
         extractArxiv: "readonly",
         extractMastodon: "readonly",
+        extractStackOverflow: "readonly",
       },
     },
   },
@@ -83,6 +84,7 @@ export default [
       "content/extractors/lobsters.js",
       "content/extractors/github.js",
       "content/extractors/mastodon.js",
+      "content/extractors/stackoverflow.js",
     ],
     languageOptions: {
       globals: {

--- a/apogee-extension/lib/extract/pageExtraction.js
+++ b/apogee-extension/lib/extract/pageExtraction.js
@@ -86,6 +86,7 @@ export async function extractFromActiveTab(tab) {
           "/content/extractors/wikipedia.js",
           "/content/extractors/arxiv.js",
           "/content/extractors/mastodon.js",
+          "/content/extractors/stackoverflow.js",
           "/content/content.js",
         ],
       });

--- a/apogee-extension/lib/summarize/ollamaSummarize.js
+++ b/apogee-extension/lib/summarize/ollamaSummarize.js
@@ -66,7 +66,8 @@ export async function* summarizeText(
     return;
   }
 
-  const isDiscussion = type === "hackernews" || type === "reddit";
+  const isDiscussion =
+    type === "hackernews" || type === "reddit" || type === "stackoverflow";
   const buildPrompt = isDiscussion ? buildDiscussionPrompt : buildSummaryPrompt;
 
   const postExcerpt = isDiscussion ? discussionPostExcerpt(text) : "";

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -487,6 +487,7 @@ const EXTRACTOR_INFO = {
   wikipedia: { label: "Wikipedia", icon: "wikipedia" },
   lobsters: { label: "Lobste.rs", icon: "globe" },
   mastodon: { label: "Mastodon", icon: "globe" },
+  stackoverflow: { label: "Stack Overflow", icon: "globe" },
   "multi-tab": { label: "Multi-Tab", icon: "lines" },
   pdf: { label: "PDF", icon: "filetext" },
 };

--- a/apogee-extension/tests/extractors/README.md
+++ b/apogee-extension/tests/extractors/README.md
@@ -12,18 +12,19 @@ npm test
 
 Read the one closest to what you're building:
 
-| File                 | Shows                                                                   |
-| -------------------- | ----------------------------------------------------------------------- |
-| `arxiv.test.js`      | Clean extraction of title, authors, subjects, and abstract from arXiv   |
-| `bilibili.test.js`   | Subtitle fetch via `chrome` stub, multi-part page selection, null cases |
-| `gmail.test.js`      | The simplest shape: synchronous, DOM only                               |
-| `github.test.js`     | Landing page, issues, and fetching diffs for pull requests              |
-| `hackernews.test.js` | Feeding the shared thread representation in `thread.js`                 |
-| `lobsters.test.js`   | Another thread-based extractor, same shape as Hacker News               |
-| `reddit.test.js`     | An extractor that reads a site API, with `fetch` stubbed                |
-| `thread.test.js`     | Testing shared machinery directly, with no site extractor               |
-| `wikipedia.test.js`  | Cutting a page down, and returning `null` to fall through               |
-| `youtube.test.js`    | Caption URL security checks, transcript parsing, and `chrome` stubbing  |
+| File                    | Shows                                                                   |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `arxiv.test.js`         | Clean extraction of title, authors, subjects, and abstract from arXiv   |
+| `bilibili.test.js`      | Subtitle fetch via `chrome` stub, multi-part page selection, null cases |
+| `gmail.test.js`         | The simplest shape: synchronous, DOM only                               |
+| `github.test.js`        | Landing page, issues, and fetching diffs for pull requests              |
+| `hackernews.test.js`    | Feeding the shared thread representation in `thread.js`                 |
+| `lobsters.test.js`      | Another thread-based extractor, same shape as Hacker News               |
+| `reddit.test.js`        | An extractor that reads a site API, with `fetch` stubbed                |
+| `stackoverflow.test.js` | Question, accepted answer, score ranking, and comment hierarchy         |
+| `thread.test.js`        | Testing shared machinery directly, with no site extractor               |
+| `wikipedia.test.js`     | Cutting a page down, and returning `null` to fall through               |
+| `youtube.test.js`       | Caption URL security checks, transcript parsing, and `chrome` stubbing  |
 
 ## Writing a test
 

--- a/apogee-extension/tests/extractors/fixtures/stackoverflow-question.html
+++ b/apogee-extension/tests/extractors/fixtures/stackoverflow-question.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>When should I use a decimal? - Stack Overflow</title>
+  </head>
+  <body>
+    <div id="content">
+      <div id="question-header">
+        <h1 itemprop="name">
+          <a href="/questions/4/when-should-i-use-a-decimal" class="question-hyperlink">When should I use a decimal?</a>
+        </h1>
+      </div>
+
+      <div id="question" class="question" data-questionid="4">
+        <div class="js-voting-container">
+          <div class="js-vote-count" data-value="42">42</div>
+        </div>
+        <div class="postcell">
+          <div class="s-prose js-post-body" itemprop="text">
+            <p>I need to store currency. Should the field be decimal or double?</p>
+          </div>
+          <div class="post-taglist">
+            <a href="/questions/tagged/c%23" class="s-tag post-tag">c#</a>
+            <a href="/questions/tagged/floating-point" class="s-tag post-tag">floating-point</a>
+          </div>
+          <div class="post-signature owner">
+            <div class="user-info">
+              <div class="user-details">
+                <a href="/users/2/alice">alice</a>
+              </div>
+            </div>
+          </div>
+          <div class="comments">
+            <ul class="comments-list">
+              <li class="comment">
+                <div class="comment-body">
+                  <span class="comment-copy">What range of values do you need?</span>
+                  <a href="/users/3/bob" class="comment-user">bob</a>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div id="answers">
+        <div id="answer-7" class="answer accepted-answer" data-answerid="7" itemprop="acceptedAnswer">
+          <div class="js-voting-container">
+            <div class="js-vote-count" data-value="5">5</div>
+          </div>
+          <div class="answercell">
+            <div class="s-prose js-post-body" itemprop="text">
+              <p>Use decimal for currency so you do not accumulate binary rounding error.</p>
+            </div>
+            <div class="user-info">
+              <div class="user-details">
+                <a href="/users/1/carol">carol</a>
+              </div>
+            </div>
+            <div class="comments">
+              <ul class="comments-list">
+                <li class="comment">
+                  <div class="comment-body">
+                    <span class="comment-copy">This is the right default for money.</span>
+                    <a href="/users/4/dave" class="comment-user">dave</a>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div id="answer-8" class="answer" data-answerid="8">
+          <div class="js-voting-container">
+            <div class="js-vote-count" data-value="100">100</div>
+          </div>
+          <div class="answercell">
+            <div class="s-prose js-post-body" itemprop="text">
+              <p>Double is faster, but the extra precision is rarely worth the rounding surprises.</p>
+            </div>
+            <div class="user-info">
+              <div class="user-details">
+                <a href="/users/5/erin">erin</a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div id="answer-9" class="answer" data-answerid="9">
+          <div class="js-voting-container">
+            <div class="js-vote-count" data-value="12">12</div>
+          </div>
+          <div class="answercell">
+            <div class="s-prose js-post-body" itemprop="text">
+              <p>Integers of cents avoid the question entirely.</p>
+            </div>
+            <div class="user-info">
+              <div class="user-details">
+                <a href="/users/6/frank">frank</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apogee-extension/tests/extractors/stackoverflow.test.js
+++ b/apogee-extension/tests/extractors/stackoverflow.test.js
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert";
+import { loadExtractors } from "./helpers/extractorHarness.js";
+
+const FILES = ["extractors/thread.js", "extractors/stackoverflow.js"];
+const QUESTION_URL =
+  "https://stackoverflow.com/questions/4/when-should-i-use-a-decimal";
+
+function extract(url = QUESTION_URL, options = {}) {
+  const { extractStackOverflow } = loadExtractors({
+    files: FILES,
+    url,
+    fixture: "stackoverflow-question.html",
+    ...options,
+  });
+  return extractStackOverflow();
+}
+
+test("extractStackOverflow pulls question metadata off a question page", () => {
+  const result = extract();
+
+  assert.strictEqual(result.type, "stackoverflow");
+  assert.strictEqual(result.title, "When should I use a decimal?");
+  assert.strictEqual(result.url, QUESTION_URL);
+  assert.match(result.content, /^Stack Overflow question/);
+  assert.match(result.content, /Tags: c#, floating-point/);
+  assert.match(result.content, /score 42 \| by alice/);
+  assert.match(result.content, /I need to store currency/);
+  assert.match(
+    result.content,
+    /Question comments:\n- bob: What range of values do you need\?/,
+  );
+});
+
+test("extractStackOverflow keeps the accepted answer and ranks the rest by score", () => {
+  const content = extract().content;
+
+  assert.match(
+    content,
+    /\[1\] <replies: 1> \(score: 5\) \[accepted\] carol: Use decimal for currency/,
+  );
+  assert.match(content, /\[1\.1\] dave: This is the right default for money\./);
+  assert.match(content, /\[2\] \(score: 100\) erin: Double is faster/);
+  assert.match(content, /\[3\] \(score: 12\) frank: Integers of cents/);
+});
+
+test("extractStackOverflow prefers accepted then highest scores when capping answers", () => {
+  const answers = Array.from({ length: 10 }, (_, i) => {
+    const score = 90 - i * 10;
+    const accepted = i === 9;
+    return `
+      <div class="answer${accepted ? " accepted-answer" : ""}" data-answerid="${i}">
+        <div class="js-vote-count" data-value="${accepted ? 1 : score}">${accepted ? 1 : score}</div>
+        <div class="s-prose js-post-body">Answer from author${i} with score ${accepted ? 1 : score}.</div>
+        <div class="user-details"><a>author${i}</a></div>
+      </div>`;
+  }).join("");
+
+  const html = `<!doctype html>
+    <html>
+      <body>
+        <div id="question-header"><h1><a class="question-hyperlink">Cap test</a></h1></div>
+        <div id="question" class="question">
+          <div class="js-vote-count" data-value="1">1</div>
+          <div class="s-prose js-post-body">Question body.</div>
+        </div>
+        <div id="answers">${answers}</div>
+      </body>
+    </html>`;
+
+  const { extractStackOverflow } = loadExtractors({
+    files: FILES,
+    url: QUESTION_URL,
+    html,
+  });
+  const content = extractStackOverflow().content;
+
+  assert.match(content, /\[accepted\] author9:/);
+  assert.match(content, /author0:/);
+  assert.match(content, /author6:/);
+  assert.doesNotMatch(content, /author7:/);
+  assert.doesNotMatch(content, /author8:/);
+});
+
+test("extractStackOverflow handles Stack Exchange network hosts", () => {
+  const result = extract(
+    "https://unix.stackexchange.com/questions/4/when-should-i-use-a-decimal",
+  );
+  assert.strictEqual(result.type, "stackoverflow");
+  assert.strictEqual(
+    result.url,
+    "https://unix.stackexchange.com/questions/4/when-should-i-use-a-decimal",
+  );
+});
+
+test("extractStackOverflow returns null off pages it does not handle", () => {
+  for (const url of [
+    "https://stackoverflow.com/questions",
+    "https://stackoverflow.com/questions/tagged/javascript",
+    "https://stackoverflow.com/users/2/alice",
+    "https://stackoverflow.com/search?q=decimal",
+    "https://example.com/questions/4/not-stackoverflow",
+  ]) {
+    assert.strictEqual(extract(url), null, `expected null for ${url}`);
+  }
+});
+
+test("extractStackOverflow reads the DOM without a network dependency", () => {
+  let fetched = false;
+  const result = extract(QUESTION_URL, {
+    fetch() {
+      fetched = true;
+      throw new Error("unexpected fetch");
+    },
+  });
+
+  assert.strictEqual(result.type, "stackoverflow");
+  assert.strictEqual(fetched, false);
+});

--- a/apogee-extension/tests/extractors/thread.test.js
+++ b/apogee-extension/tests/extractors/thread.test.js
@@ -12,6 +12,24 @@ function loadThread() {
 
 const hasText = (n) => !!n.text;
 
+test("formatThreadComments marks accepted answers", () => {
+  const { buildThreadNodes, formatThreadComments } = loadThread();
+  const nodes = buildThreadNodes([
+    {
+      depth: 0,
+      author: "carol",
+      text: "use decimal",
+      score: 5,
+      accepted: true,
+    },
+  ]);
+
+  assert.match(
+    formatThreadComments(nodes),
+    /\[1\] \(score: 5\) \[accepted\] carol: use decimal/,
+  );
+});
+
 test("directReplies counts only replies that survive eligibility", () => {
   const { buildThreadNodes, selectThreadComments, formatThreadComments } =
     loadThread();


### PR DESCRIPTION
## Summary

- Add a DOM-only extractor for Stack Overflow / Stack Exchange question pages (`/questions/<id>/...`).
- Keep the question body, mark the accepted answer, and keep the next few answers by score, with answer comments in `thread.js` path notation.
- Return `null` for tag listings, user profiles, the `/questions` index, and search so Readability still handles those.
- Route this type through the existing discussion summarizer and show a Stack Overflow extractor chip.

Question pages currently flatten question, answers, and vote counts into one blob. This extractor preserves that structure from the HTML already in the tab. It does not paginate answers or expand collapsed comment threads, so it summarizes whatever the current page already rendered, capped at the accepted answer plus the next highest-scoring answers (8 total).

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test` (283 passed)
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [ ] Manually exercised the change in a loaded browser extension

## Privacy impact

- [x] No new outbound network calls
- [ ] Adds/changes a network call (described above, docs updated)
- [x] Permissions unchanged, or all four of manifest / README / PRIVACY / store-listing updated together

Fixes #30