### PR TITLE
refactor(background): parameterize the loopback streaming path - (PR2 of  7 planned PRs)

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -214,23 +214,37 @@ function relayToOffscreenStream(popupPort, streamId) {
   });
 }
 
-const ALLOWED_OLLAMA_HOSTS = new Set(["127.0.0.1", "localhost"]);
+const ALLOWED_LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost"]);
 
-function validateOllamaHost(host) {
+// The label is woven into the thrown messages, which ERROR.md documents word
+// for word, so the Ollama default has to keep producing exactly the strings it
+// produced before.
+function validateLoopbackHost(host, label = "Ollama") {
   let url;
   try {
     url = new URL(host);
   } catch {
-    throw new Error("Invalid Ollama host");
+    throw new Error(`Invalid ${label} host`);
   }
   if (url.protocol !== "http:") {
-    throw new Error(`Disallowed Ollama protocol: ${url.protocol}`);
+    throw new Error(`Disallowed ${label} protocol: ${url.protocol}`);
   }
-  if (!ALLOWED_OLLAMA_HOSTS.has(url.hostname)) {
-    throw new Error(`Disallowed Ollama host: ${url.hostname}`);
+  if (!ALLOWED_LOOPBACK_HOSTS.has(url.hostname)) {
+    throw new Error(`Disallowed ${label} host: ${url.hostname}`);
   }
   return url.toString().replace(/\/+$/, "");
 }
+
+// What a loopback HTTP provider contributes to a generation job: the client
+// that talks to it, the name its errors are written in, and the message action
+// its stream arrives on. Everything else in the two functions below is the
+// same whichever server is answering. Ollama is the default, so its call sites
+// pass nothing and behave exactly as before.
+const OLLAMA_PROVIDER = {
+  label: "Ollama",
+  streamKind: "ollama-stream",
+  chatStream,
+};
 
 async function getRelevantAskContent(content, question) {
   if (!hasOffscreenAPI) return truncateForPrompt(content);
@@ -287,7 +301,7 @@ function createBufferedStream(streamId, { finalize, model, title, url }) {
   return { stream, finish, emitChunk };
 }
 
-async function startOllamaStream(
+async function startLocalHttpStream(
   streamId,
   {
     action,
@@ -303,6 +317,7 @@ async function startOllamaStream(
     language,
     translationEngine,
   },
+  client = OLLAMA_PROVIDER,
 ) {
   const { stream, finish, emitChunk } = createBufferedStream(streamId, {
     finalize,
@@ -313,7 +328,7 @@ async function startOllamaStream(
 
   let validHost;
   try {
-    validHost = validateOllamaHost(host);
+    validHost = validateLoopbackHost(host, client.label);
   } catch (err) {
     finish({ type: "error", error: err.message });
     return;
@@ -354,6 +369,7 @@ async function startOllamaStream(
           signal: stream.controller.signal,
         },
         {
+          chatStreamFn: client.chatStream,
           translateFn,
           onProgress: (p) => {
             if (p.stage === "truncated") {
@@ -378,7 +394,7 @@ async function startOllamaStream(
         buildAnswerPrompt(title, url, relevantContent, question),
         customInstructions,
       );
-      const chat = (p, opts) => chatStream(validHost, model, p, opts);
+      const chat = (p, opts) => client.chatStream(validHost, model, p, opts);
       generator = streamInTargetLanguage(
         chat,
         prompt,
@@ -386,7 +402,7 @@ async function startOllamaStream(
         { signal: stream.controller.signal, translateFn },
       );
     } else {
-      throw new Error(`Unknown ollama-stream action: ${action}`);
+      throw new Error(`Unknown ${client.streamKind} action: ${action}`);
     }
 
     for await (const token of generator) {
@@ -662,7 +678,7 @@ async function runBackgroundSummarize(
   let streamId;
   if (providerType === PROVIDERS.LOCAL) {
     streamId = nextStreamId("ollama");
-    startOllamaStream(streamId, { ...common, host: settings.ollamaHost });
+    startLocalHttpStream(streamId, { ...common, host: settings.ollamaHost });
   } else if (providerType === PROVIDERS.TRANSFORMERS) {
     streamId = nextStreamId("transformers");
     startTransformersStream(streamId, common);
@@ -867,14 +883,15 @@ async function fetchBilibiliSubtitles({ aid, bvid, cid, preferredLang }) {
     .filter((seg) => seg.text);
 }
 
-async function generateOllamaSuggestions(
+async function generateLocalSuggestions(
   host,
   model,
   { title, url, summary, language },
+  client = OLLAMA_PROVIDER,
 ) {
-  const validHost = validateOllamaHost(host);
+  const validHost = validateLoopbackHost(host, client.label);
   const prompt = buildSuggestQuestionsPrompt(title, url, summary);
-  const chat = (p, opts) => chatStream(validHost, model, p, opts);
+  const chat = (p, opts) => client.chatStream(validHost, model, p, opts);
   const qLanguage = await resolveEffectiveLanguage(summary, language);
   const text = await generateInTargetLanguage(chat, prompt, qLanguage);
   return parseSuggestedQuestions(text);
@@ -904,7 +921,7 @@ async function runSuggestQuestionsJob(payload) {
     let questions = [];
     try {
       if (providerType === PROVIDERS.LOCAL) {
-        questions = await generateOllamaSuggestions(host, model, {
+        questions = await generateLocalSuggestions(host, model, {
           title,
           url,
           summary,
@@ -1256,7 +1273,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         case "ollama-stream": {
           const streamId = nextStreamId("ollama");
-          startOllamaStream(streamId, message.payload);
+          startLocalHttpStream(streamId, message.payload);
           sendResponse({ streamId });
           break;
         }
@@ -1290,7 +1307,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         case "ollama-status": {
           let validHost;
           try {
-            validHost = validateOllamaHost(message.payload.host);
+            validHost = validateLoopbackHost(message.payload.host);
           } catch {
             sendResponse({ connected: false, models: [] });
             break;


### PR DESCRIPTION
Ollama is currently the only provider that generates over loopback HTTP, so startOllamaStream, generateOllamaSuggestions and validateOllamaHost each name it directly. Of the ~110 lines in startOllamaStream, three are actually Ollama-specific: the host validator call, the client used in the ask branch, and the chatStreamFn that summarizeText picks up by default. Buffered stream setup, settings load, progress reporting, translation wiring, the summarize/ask split and the emit loop are all provider-agnostic.

Rather than clone those ~137 lines for a second loopback provider, this threads the provider-specific pieces through as an argument:

  startLocalHttpStream(streamId, payload, client = OLLAMA_PROVIDER)
  generateLocalSuggestions(host, model, opts, client = OLLAMA_PROVIDER)
  validateLoopbackHost(host, label = "Ollama")

Every existing call site passes no client and no label, so Ollama takes the same path with the same values it did before. summarizeText is now handed chatStreamFn explicitly instead of relying on its default, which for Ollama is the identical function. The same default-parameter injection is already how summarizeText, summarizeYoutube and mapReduceStream take their dependencies.

ERROR.md documents four of the thrown strings word for word, so the label and streamKind defaults are chosen to reproduce them exactly: "Invalid Ollama host", "Disallowed Ollama protocol: ...", "Disallowed Ollama host: ..." and "Unknown ollama-stream action: ...". Verified against the rendered messages, so the docs stay accurate without being touched.

No behaviour change, no new provider. Groundwork for #91.

Part of #91

## Summary

<!-- What does this PR change, and why? -->

## Test plan


- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [ ] Manually exercised the change in a loaded browser extension

## Privacy impact

<!-- Does this add, remove, or change any outbound network request or permission? -->

- [x] No new outbound network calls
- [ ] Adds/changes a network call (described above, docs updated)

<!-- Permissions and network behaviour are described in four places that must
     agree: apogee-extension/manifest.json, README.md (Privacy & Permissions),
     PRIVACY.md, and store-listing.md (permission justifications). A claim in
     one and not the others is what store reviewers catch. -->

- [x] Permissions unchanged, or all four of manifest / README / PRIVACY /
      store-listing updated together
