### PR TITLE
feat(engines): let a reported context window override the model-name guess (PR 3 of 7 planned PRs for #91)

### DIFF
--- a/apogee-extension/lib/engines/modelLimits.js
+++ b/apogee-extension/lib/engines/modelLimits.js
@@ -46,9 +46,31 @@ function getOllamaContextTokens(model) {
   );
 }
 
-export function getMaxChunkChars(model) {
+function isPositiveTokenCount(value) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * How much text to put in one chunk for a given model.
+ *
+ * Every branch below infers the context window from the model name, which
+ * works while the name implies the window. It does not always: a llama.cpp
+ * server takes its window from its own `-c` launch flag, so the same GGUF can
+ * be serving 4096 tokens or 32768 and the name reads identically either way.
+ * Guessing there is not merely imprecise, it can overflow -- a model named for
+ * a 128k window, run with `-c 4096`, would be handed chunks twenty times too
+ * large. So a caller that has asked the server what it is actually running
+ * passes `contextTokensOverride`, and that wins outright.
+ *
+ * Callers without one pass nothing and keep the name-based behaviour.
+ */
+export function getMaxChunkChars(model, contextTokensOverride) {
   let contextTokens;
-  if ((model || "").endsWith("-MLC")) {
+  if (isPositiveTokenCount(contextTokensOverride)) {
+    // Still capped: a reported 128k window would otherwise produce a single
+    // chunk far larger than is practical to generate from.
+    contextTokens = Math.min(contextTokensOverride, PRACTICAL_MAX_TOKENS);
+  } else if ((model || "").endsWith("-MLC")) {
     contextTokens = WEBLLM_CONTEXT_TOKENS;
   } else if (isTransformersModel(model)) {
     contextTokens = TRANSFORMERS_CONTEXT_TOKENS;

--- a/apogee-extension/tests/engines/modelLimits.test.js
+++ b/apogee-extension/tests/engines/modelLimits.test.js
@@ -43,3 +43,44 @@ test("getMaxChunks fans Transformers.js models out into far fewer chunks", () =>
   assert.equal(getMaxChunks("Qwen2.5-1.5B-Instruct-q4f16_1-MLC"), 12);
   assert.equal(getMaxChunks("llama3.1:8b"), 12);
 });
+
+// A llama.cpp server takes its context window from its own -c launch flag, so
+// the model name cannot imply it. A caller that has asked the server what it
+// is running passes the answer, and it has to beat every name-based guess.
+test("getMaxChunkChars prefers a reported context window over the model name", () => {
+  // llama3.1 would otherwise be read as a 128k model and capped to 24000.
+  assert.equal(getMaxChunkChars("llama3.1:8b"), 87808);
+  assert.equal(getMaxChunkChars("llama3.1:8b", 4096), 8192);
+});
+
+test("getMaxChunkChars applies a reported window to every model-name shape", () => {
+  for (const model of [
+    "llama3.1:8b",
+    "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+    TRANSFORMERS_MODELS[0].id,
+    "Qwen/Qwen2.5-0.5B-Instruct-GGUF:Q4_K_M",
+    "",
+  ]) {
+    assert.equal(getMaxChunkChars(model, 4096), 8192);
+  }
+});
+
+test("getMaxChunkChars still caps a large reported window at the practical max", () => {
+  assert.equal(getMaxChunkChars("some-model", 32768), 87808);
+  assert.equal(getMaxChunkChars("some-model", 1000000), 87808);
+});
+
+test("getMaxChunkChars keeps a floor under a tiny reported window", () => {
+  assert.equal(getMaxChunkChars("some-model", 1024), 2048);
+});
+
+// Everything that does not pass an override has to behave exactly as before.
+test("getMaxChunkChars ignores an absent or unusable override", () => {
+  for (const override of [undefined, null, 0, -1, NaN, Infinity, "4096", {}]) {
+    assert.equal(
+      getMaxChunkChars("llama3.1:8b", override),
+      getMaxChunkChars("llama3.1:8b"),
+      `override ${String(override)} should have been ignored`,
+    );
+  }
+});


### PR DESCRIPTION
## Previously in this series

**PR 1 — `feat/llamacpp-client`** (open)

Added `lib/engines/llamaCppClient.js`: `chatStream` (SSE parsing against `/v1/chat/completions`) and `checkHealth` (`/health` for reachability, `/v1/models` for the model name, `/props` for the context window). Verified against a live `llama-server` b10603, including two wire-format quirks — the opening chunk sends `content: null`, and `[DONE]` arrives with no trailing blank line.

**PR 2 — `refactor/local-http-stream`** (open)

Parameterized the loopback streaming path in `background/service-worker.js`. `startOllamaStream` → `startLocalHttpStream(streamId, payload, client = OLLAMA_PROVIDER)`, plus the same treatment for the suggestions helper and the host validator. Of its ~110 lines only three were Ollama-specific, so a second provider now needs no cloned copy. Pure refactor — every existing call site passes no client and behaves identically, and the four error strings `ERROR.md` documents verbatim are reproduced exactly.

Neither is wired to anything yet — that's PR 5. All three are mutually independent and reviewable in any order.

## This PR

Makes chunk sizing able to use a context window the server reports, instead of one inferred from the model name.

`getMaxChunkChars` infers the window from the name — `-MLC` means WebLLM, a known id means Transformers.js, and everything else falls through to prefix-matching a table of Ollama families. That last branch is unconditional, so any unrecognized name is treated as an Ollama model and sized from a guess.

For llama.cpp that can't be made to work: `llama-server` takes its window from its own `-c` flag, so the same GGUF serves 4096 tokens or 32768 with an identical name. Measured against b10603 started with `-c 4096`:

```
/props      default_generation_settings.n_ctx = 4096
/v1/models  meta.n_ctx = 4096   meta.n_ctx_train = 32768
```

Separate fields precisely because they diverge. A file named for a 128k model run with `-c 4096` currently gets 87,808-character chunks against a window holding roughly 8,000 — an overflow, not a slow summary.

So:

```
getMaxChunkChars(model, contextTokensOverride)
```

A caller that asked the server what it's running passes the answer and it wins outright. The practical cap and floor still apply. Callers with nothing to report pass nothing and keep existing behavior — pinned by a test across `undefined`, `null`, `0`, negatives, `NaN`, `Infinity`, and non-numbers.

(Named `contextTokensOverride` rather than your `contextTokens`/`n_ctx` to signal that it beats every other branch rather than being one more input — happy to rename if you prefer.)

## Tests

Five new cases in `tests/engines/modelLimits.test.js`: override beats the name guess (the concrete `llama3.1:8b` 87,808 → 8,192 case); override applies across every name shape; cap and floor still hold; and the regression guard above.

256 pass · lint clean · Prettier clean · both builds green.

Nothing passes an override yet — the llama.cpp path that will is PR 5. This lands inert.

Part of #91


## Summary

<!-- What does this PR change, and why? -->

## Test plan

<!-- How did you verify this? Check the boxes you actually ran. -->

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [x] Manually exercised the change in a loaded browser extension

## Privacy impact

<!-- Does this add, remove, or change any outbound network request or permission? -->

- [x] No new outbound network calls
- [ ] Adds/changes a network call (described above, docs updated)

<!-- Permissions and network behaviour are described in four places that must
     agree: apogee-extension/manifest.json, README.md (Privacy & Permissions),
     PRIVACY.md, and store-listing.md (permission justifications). A claim in
     one and not the others is what store reviewers catch. -->

- [x] Permissions unchanged, or all four of manifest / README / PRIVACY /
      store-listing updated together
