### PR TITLE
feat(engines): add llama.cpp client for llama-server

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -214,23 +214,37 @@ function relayToOffscreenStream(popupPort, streamId) {
   });
 }
 
-const ALLOWED_OLLAMA_HOSTS = new Set(["127.0.0.1", "localhost"]);
+const ALLOWED_LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost"]);
 
-function validateOllamaHost(host) {
+// The label is woven into the thrown messages, which ERROR.md documents word
+// for word, so the Ollama default has to keep producing exactly the strings it
+// produced before.
+function validateLoopbackHost(host, label = "Ollama") {
   let url;
   try {
     url = new URL(host);
   } catch {
-    throw new Error("Invalid Ollama host");
+    throw new Error(`Invalid ${label} host`);
   }
   if (url.protocol !== "http:") {
-    throw new Error(`Disallowed Ollama protocol: ${url.protocol}`);
+    throw new Error(`Disallowed ${label} protocol: ${url.protocol}`);
   }
-  if (!ALLOWED_OLLAMA_HOSTS.has(url.hostname)) {
-    throw new Error(`Disallowed Ollama host: ${url.hostname}`);
+  if (!ALLOWED_LOOPBACK_HOSTS.has(url.hostname)) {
+    throw new Error(`Disallowed ${label} host: ${url.hostname}`);
   }
   return url.toString().replace(/\/+$/, "");
 }
+
+// What a loopback HTTP provider contributes to a generation job: the client
+// that talks to it, the name its errors are written in, and the message action
+// its stream arrives on. Everything else in the two functions below is the
+// same whichever server is answering. Ollama is the default, so its call sites
+// pass nothing and behave exactly as before.
+const OLLAMA_PROVIDER = {
+  label: "Ollama",
+  streamKind: "ollama-stream",
+  chatStream,
+};
 
 async function getRelevantAskContent(content, question) {
   if (!hasOffscreenAPI) return truncateForPrompt(content);
@@ -287,7 +301,7 @@ function createBufferedStream(streamId, { finalize, model, title, url }) {
   return { stream, finish, emitChunk };
 }
 
-async function startOllamaStream(
+async function startLocalHttpStream(
   streamId,
   {
     action,
@@ -303,6 +317,7 @@ async function startOllamaStream(
     language,
     translationEngine,
   },
+  client = OLLAMA_PROVIDER,
 ) {
   const { stream, finish, emitChunk } = createBufferedStream(streamId, {
     finalize,
@@ -313,7 +328,7 @@ async function startOllamaStream(
 
   let validHost;
   try {
-    validHost = validateOllamaHost(host);
+    validHost = validateLoopbackHost(host, client.label);
   } catch (err) {
     finish({ type: "error", error: err.message });
     return;
@@ -354,6 +369,7 @@ async function startOllamaStream(
           signal: stream.controller.signal,
         },
         {
+          chatStreamFn: client.chatStream,
           translateFn,
           onProgress: (p) => {
             if (p.stage === "truncated") {
@@ -378,7 +394,7 @@ async function startOllamaStream(
         buildAnswerPrompt(title, url, relevantContent, question),
         customInstructions,
       );
-      const chat = (p, opts) => chatStream(validHost, model, p, opts);
+      const chat = (p, opts) => client.chatStream(validHost, model, p, opts);
       generator = streamInTargetLanguage(
         chat,
         prompt,
@@ -386,7 +402,7 @@ async function startOllamaStream(
         { signal: stream.controller.signal, translateFn },
       );
     } else {
-      throw new Error(`Unknown ollama-stream action: ${action}`);
+      throw new Error(`Unknown ${client.streamKind} action: ${action}`);
     }
 
     for await (const token of generator) {
@@ -662,7 +678,7 @@ async function runBackgroundSummarize(
   let streamId;
   if (providerType === PROVIDERS.LOCAL) {
     streamId = nextStreamId("ollama");
-    startOllamaStream(streamId, { ...common, host: settings.ollamaHost });
+    startLocalHttpStream(streamId, { ...common, host: settings.ollamaHost });
   } else if (providerType === PROVIDERS.TRANSFORMERS) {
     streamId = nextStreamId("transformers");
     startTransformersStream(streamId, common);
@@ -867,14 +883,15 @@ async function fetchBilibiliSubtitles({ aid, bvid, cid, preferredLang }) {
     .filter((seg) => seg.text);
 }
 
-async function generateOllamaSuggestions(
+async function generateLocalSuggestions(
   host,
   model,
   { title, url, summary, language },
+  client = OLLAMA_PROVIDER,
 ) {
-  const validHost = validateOllamaHost(host);
+  const validHost = validateLoopbackHost(host, client.label);
   const prompt = buildSuggestQuestionsPrompt(title, url, summary);
-  const chat = (p, opts) => chatStream(validHost, model, p, opts);
+  const chat = (p, opts) => client.chatStream(validHost, model, p, opts);
   const qLanguage = await resolveEffectiveLanguage(summary, language);
   const text = await generateInTargetLanguage(chat, prompt, qLanguage);
   return parseSuggestedQuestions(text);
@@ -904,7 +921,7 @@ async function runSuggestQuestionsJob(payload) {
     let questions = [];
     try {
       if (providerType === PROVIDERS.LOCAL) {
-        questions = await generateOllamaSuggestions(host, model, {
+        questions = await generateLocalSuggestions(host, model, {
           title,
           url,
           summary,
@@ -1256,7 +1273,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         case "ollama-stream": {
           const streamId = nextStreamId("ollama");
-          startOllamaStream(streamId, message.payload);
+          startLocalHttpStream(streamId, message.payload);
           sendResponse({ streamId });
           break;
         }
@@ -1290,7 +1307,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         case "ollama-status": {
           let validHost;
           try {
-            validHost = validateOllamaHost(message.payload.host);
+            validHost = validateLoopbackHost(message.payload.host);
           } catch {
             sendResponse({ connected: false, models: [] });
             break;

--- a/apogee-extension/lib/engines/llamaCppClient.js
+++ b/apogee-extension/lib/engines/llamaCppClient.js
@@ -94,8 +94,14 @@ function readEventBlock(block, model) {
       );
     }
 
+    // An error can also arrive mid-stream, after a 200. The payload is already
+    // parsed here, so this maps it directly rather than going back through
+    // httpError and parsing it a second time.
     if (parsed?.error) {
-      throw httpError(payload, "streamed error", model);
+      throw new LlamaCppError(
+        envelopeMessage(parsed.error, model) ||
+          `llama.cpp returned an error for model '${model}': ${payload}`,
+      );
     }
 
     const content = parsed?.choices?.[0]?.delta?.content;
@@ -185,6 +191,17 @@ export async function* chatStream(
       throw new LlamaCppError("Generation was cancelled.");
     }
     throw connectError(base, err);
+  } finally {
+    // Breaking out of the loop early, which is what cancelling a summary does,
+    // resumes this generator with a return completion: that skips the catch
+    // but still runs this. cancel() is what tells the body to stop and lets
+    // the connection go; releaseLock() then leaves no locked stream behind.
+    try {
+      await reader.cancel();
+    } catch {}
+    try {
+      reader.releaseLock();
+    } catch {}
   }
 }
 

--- a/apogee-extension/lib/engines/llamaCppClient.js
+++ b/apogee-extension/lib/engines/llamaCppClient.js
@@ -1,0 +1,230 @@
+import { UserFacingError } from "../util/userError.js";
+
+class LlamaCppError extends UserFacingError {}
+
+/**
+ * llama-server's context window is set by its `-c` launch flag, not by the
+ * model, so a model name says nothing about it. When neither `/props` nor
+ * `/v1/models` reports the running value, callers fall back to this: low
+ * enough to be safe on a modestly configured server.
+ */
+export const DEFAULT_CONTEXT_TOKENS = 8192;
+
+const SSE_DONE = "[DONE]";
+
+function connectError(host, err) {
+  return new LlamaCppError(
+    `Could not connect to llama.cpp at ${host}. Is llama-server running and ` +
+      `listening on that address? Error: ${err?.message ?? err}`,
+  );
+}
+
+// Every llama-server failure comes back as {error:{message,type,code}}, but a
+// server_error's message can be a raw C++ exception dump ("[json.exception.
+// parse_error.101] parse error at line 1, column 2..."), which means nothing
+// to the person reading it. Request-shaped errors (400, 404) are written for
+// a caller, so those pass through.
+function envelopeMessage(error, model) {
+  if (error?.type === "server_error") {
+    return (
+      `llama.cpp failed while handling the request for model '${model}'. ` +
+      `Check the llama-server console for details.`
+    );
+  }
+  const detail = typeof error?.message === "string" ? error.message : null;
+  return detail
+    ? `llama.cpp returned an error for model '${model}': ${detail}`
+    : null;
+}
+
+function httpError(body, status, model) {
+  let parsed = null;
+  try {
+    parsed = JSON.parse(body);
+  } catch {}
+  const described = envelopeMessage(parsed?.error, model);
+  return new LlamaCppError(
+    described ||
+      `llama.cpp returned an error for model '${model}': ${body || status}`,
+  );
+}
+
+// An SSE event may carry several lines, of which only `data:` ones are
+// payload. Anything else (a `:` keepalive comment, an `event:` name) is
+// skipped rather than parsed, so a server version that starts emitting them
+// cannot break the stream.
+function dataPayloadsOf(block) {
+  const payloads = [];
+  for (const raw of block.split("\n")) {
+    const line = raw.trim();
+    if (!line.startsWith("data:")) continue;
+    payloads.push(line.slice(5).trim());
+  }
+  return payloads;
+}
+
+function readEventBlock(block, model) {
+  const tokens = [];
+  for (const payload of dataPayloadsOf(block)) {
+    if (payload === SSE_DONE) return { tokens, done: true };
+    if (!payload) continue;
+
+    let parsed;
+    try {
+      parsed = JSON.parse(payload);
+    } catch (err) {
+      throw new LlamaCppError(
+        `llama.cpp sent a malformed response for model '${model}': ${err.message}`,
+      );
+    }
+
+    if (parsed?.error) {
+      throw httpError(payload, "streamed error", model);
+    }
+
+    const content = parsed?.choices?.[0]?.delta?.content;
+    // The opening chunk announces the assistant role with `content: null`, and
+    // the closing chunk carries finish_reason with an empty delta. Checking the
+    // type skips both, while still passing a single-space token through, which
+    // a truthiness check would drop.
+    if (typeof content === "string" && content !== "") tokens.push(content);
+  }
+  return { tokens, done: false };
+}
+
+export async function* chatStream(
+  host,
+  model,
+  prompt,
+  { signal, system } = {},
+) {
+  const messages = system
+    ? [
+        { role: "system", content: system },
+        { role: "user", content: prompt },
+      ]
+    : [{ role: "user", content: prompt }];
+
+  const base = host.replace(/\/+$/, "");
+
+  let response;
+  try {
+    response = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model, messages, stream: true }),
+      signal,
+    });
+  } catch (err) {
+    if (err?.name === "AbortError")
+      throw new LlamaCppError("Generation was cancelled.");
+    throw connectError(base, err);
+  }
+
+  if (!response.ok) {
+    let body = "";
+    try {
+      body = await response.text();
+    } catch {}
+    throw httpError(body, response.status, model);
+  }
+
+  if (!response.body) return;
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let boundary;
+      while ((boundary = buffer.indexOf("\n\n")) !== -1) {
+        const block = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        const { tokens, done: finished } = readEventBlock(block, model);
+        yield* tokens;
+        if (finished) return;
+      }
+    }
+
+    // `data: [DONE]` arrives with no trailing blank line, so the final event is
+    // still sitting in the buffer once the reader finishes. Without this flush
+    // the sentinel is never read. ollamaClient.js flushes its last NDJSON line
+    // for the same reason.
+    const trailing = buffer.trim();
+    if (trailing) {
+      const { tokens } = readEventBlock(trailing, model);
+      yield* tokens;
+    }
+  } catch (err) {
+    if (err instanceof LlamaCppError) throw err;
+    if (err?.name === "AbortError" || signal?.aborted) {
+      throw new LlamaCppError("Generation was cancelled.");
+    }
+    throw connectError(base, err);
+  }
+}
+
+async function getJson(url, timeoutMs) {
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return null;
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function positiveInt(value) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+}
+
+/**
+ * Whether llama-server is reachable, which model(s) it is serving, and the
+ * context window it is actually running with.
+ *
+ * `/health` answering is the whole of "is it up". The two lookups after it
+ * only enrich that answer, so a server with `/props` disabled
+ * (`endpoint_props: false`) or an unfamiliar `/v1/models` shape still reports
+ * as connected. `contextTokens` is null when neither reported one, leaving the
+ * caller to apply DEFAULT_CONTEXT_TOKENS rather than having a guess handed to
+ * it as though it were detected.
+ */
+export async function checkHealth(host, timeoutMs = 3000) {
+  const base = host.replace(/\/+$/, "");
+  const disconnected = { connected: false, models: [], contextTokens: null };
+
+  let health;
+  try {
+    health = await fetch(`${base}/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch {
+    return disconnected;
+  }
+  if (!health.ok) return disconnected;
+
+  const [props, modelList] = await Promise.all([
+    getJson(`${base}/props`, timeoutMs),
+    getJson(`${base}/v1/models`, timeoutMs),
+  ]);
+
+  const entries = Array.isArray(modelList?.data) ? modelList.data : [];
+  const models = entries
+    .map((entry) => entry?.id)
+    .filter((id) => typeof id === "string" && id);
+
+  const contextTokens =
+    positiveInt(props?.default_generation_settings?.n_ctx) ??
+    positiveInt(entries[0]?.meta?.n_ctx);
+
+  return { connected: true, models, contextTokens };
+}

--- a/apogee-extension/lib/engines/llamaCppClient.js
+++ b/apogee-extension/lib/engines/llamaCppClient.js
@@ -12,6 +12,15 @@ export const DEFAULT_CONTEXT_TOKENS = 8192;
 
 const SSE_DONE = "[DONE]";
 
+// llama-server started with `--api-key` wants it as a bearer token. Which
+// endpoints it guards has moved between versions (`/health` and `/v1/models`
+// have been public, `/props` has not), so the header goes on every request
+// rather than a guessed subset: a server that does not want it ignores it.
+function authHeaders(apiKey) {
+  const key = (apiKey || "").trim();
+  return key ? { Authorization: `Bearer ${key}` } : {};
+}
+
 function connectError(host, err) {
   return new LlamaCppError(
     `Could not connect to llama.cpp at ${host}. Is llama-server running and ` +
@@ -25,6 +34,12 @@ function connectError(host, err) {
 // to the person reading it. Request-shaped errors (400, 404) are written for
 // a caller, so those pass through.
 function envelopeMessage(error, model) {
+  if (error?.type === "authentication_error") {
+    return (
+      `llama.cpp rejected the API key. Check the key in Settings against the ` +
+      `--api-key llama-server was started with.`
+    );
+  }
   if (error?.type === "server_error") {
     return (
       `llama.cpp failed while handling the request for model '${model}'. ` +
@@ -96,7 +111,7 @@ export async function* chatStream(
   host,
   model,
   prompt,
-  { signal, system } = {},
+  { signal, system, apiKey } = {},
 ) {
   const messages = system
     ? [
@@ -111,7 +126,10 @@ export async function* chatStream(
   try {
     response = await fetch(`${base}/v1/chat/completions`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders(apiKey),
+      },
       body: JSON.stringify({ model, messages, stream: true }),
       signal,
     });
@@ -169,10 +187,11 @@ export async function* chatStream(
   }
 }
 
-async function getJson(url, timeoutMs) {
+async function getJson(url, timeoutMs, apiKey) {
   try {
     const response = await fetch(url, {
       signal: AbortSignal.timeout(timeoutMs),
+      headers: authHeaders(apiKey),
     });
     if (!response.ok) return null;
     return await response.json();
@@ -197,8 +216,12 @@ function positiveInt(value) {
  * as connected. `contextTokens` is null when neither reported one, leaving the
  * caller to apply DEFAULT_CONTEXT_TOKENS rather than having a guess handed to
  * it as though it were detected.
+ *
+ * A wrong `apiKey` does not show up here: `/health` is public on the versions
+ * checked, so the server still reports as reachable and the rejection surfaces
+ * on the first generation instead.
  */
-export async function checkHealth(host, timeoutMs = 3000) {
+export async function checkHealth(host, timeoutMs = 3000, apiKey = "") {
   const base = host.replace(/\/+$/, "");
   const disconnected = { connected: false, models: [], contextTokens: null };
 
@@ -206,6 +229,7 @@ export async function checkHealth(host, timeoutMs = 3000) {
   try {
     health = await fetch(`${base}/health`, {
       signal: AbortSignal.timeout(timeoutMs),
+      headers: authHeaders(apiKey),
     });
   } catch {
     return disconnected;
@@ -213,8 +237,8 @@ export async function checkHealth(host, timeoutMs = 3000) {
   if (!health.ok) return disconnected;
 
   const [props, modelList] = await Promise.all([
-    getJson(`${base}/props`, timeoutMs),
-    getJson(`${base}/v1/models`, timeoutMs),
+    getJson(`${base}/props`, timeoutMs, apiKey),
+    getJson(`${base}/v1/models`, timeoutMs, apiKey),
   ]);
 
   const entries = Array.isArray(modelList?.data) ? modelList.data : [];

--- a/apogee-extension/lib/engines/llamaCppClient.js
+++ b/apogee-extension/lib/engines/llamaCppClient.js
@@ -12,10 +12,11 @@ export const DEFAULT_CONTEXT_TOKENS = 8192;
 
 const SSE_DONE = "[DONE]";
 
-// llama-server started with `--api-key` wants it as a bearer token. Which
-// endpoints it guards has moved between versions (`/health` and `/v1/models`
-// have been public, `/props` has not), so the header goes on every request
-// rather than a guessed subset: a server that does not want it ignores it.
+// llama-server started with `--api-key` wants it as a bearer token. On
+// b10603 only `/health` is public; `/props` and `/v1/models` both answer 401
+// without it. Rather than encode that split, which has moved between
+// versions, the header goes on every request: a server that does not want it
+// ignores it, and model detection cannot silently break if the split changes.
 function authHeaders(apiKey) {
   const key = (apiKey || "").trim();
   return key ? { Authorization: `Bearer ${key}` } : {};
@@ -217,9 +218,10 @@ function positiveInt(value) {
  * caller to apply DEFAULT_CONTEXT_TOKENS rather than having a guess handed to
  * it as though it were detected.
  *
- * A wrong `apiKey` does not show up here: `/health` is public on the versions
- * checked, so the server still reports as reachable and the rejection surfaces
- * on the first generation instead.
+ * A wrong `apiKey` still reports connected, because `/health` is public, but
+ * both enrichment lookups answer 401 and it comes back with no models and no
+ * contextTokens. Connected with an empty model list is therefore the signature
+ * of a bad key rather than of a server that has nothing loaded.
  */
 export async function checkHealth(host, timeoutMs = 3000, apiKey = "") {
   const base = host.replace(/\/+$/, "");

--- a/apogee-extension/lib/engines/modelLimits.js
+++ b/apogee-extension/lib/engines/modelLimits.js
@@ -46,9 +46,31 @@ function getOllamaContextTokens(model) {
   );
 }
 
-export function getMaxChunkChars(model) {
+function isPositiveTokenCount(value) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * How much text to put in one chunk for a given model.
+ *
+ * Every branch below infers the context window from the model name, which
+ * works while the name implies the window. It does not always: a llama.cpp
+ * server takes its window from its own `-c` launch flag, so the same GGUF can
+ * be serving 4096 tokens or 32768 and the name reads identically either way.
+ * Guessing there is not merely imprecise, it can overflow -- a model named for
+ * a 128k window, run with `-c 4096`, would be handed chunks twenty times too
+ * large. So a caller that has asked the server what it is actually running
+ * passes `contextTokensOverride`, and that wins outright.
+ *
+ * Callers without one pass nothing and keep the name-based behaviour.
+ */
+export function getMaxChunkChars(model, contextTokensOverride) {
   let contextTokens;
-  if ((model || "").endsWith("-MLC")) {
+  if (isPositiveTokenCount(contextTokensOverride)) {
+    // Still capped: a reported 128k window would otherwise produce a single
+    // chunk far larger than is practical to generate from.
+    contextTokens = Math.min(contextTokensOverride, PRACTICAL_MAX_TOKENS);
+  } else if ((model || "").endsWith("-MLC")) {
     contextTokens = WEBLLM_CONTEXT_TOKENS;
   } else if (isTransformersModel(model)) {
     contextTokens = TRANSFORMERS_CONTEXT_TOKENS;

--- a/apogee-extension/tests/engines/llamaCppClient.test.js
+++ b/apogee-extension/tests/engines/llamaCppClient.test.js
@@ -1,0 +1,381 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import {
+  chatStream,
+  checkHealth,
+  DEFAULT_CONTEXT_TOKENS,
+} from "../../lib/engines/llamaCppClient.js";
+
+const HOST = "http://127.0.0.1:8080";
+
+// llama-server frames its stream as `data: {...}` separated by blank lines.
+// The fixtures below are shaped after a real capture from build
+// b10603-c060ca974 serving Qwen2.5-0.5B-Instruct-GGUF:Q4_K_M.
+const event = (payload) => `data: ${JSON.stringify(payload)}\n\n`;
+const token = (content) =>
+  event({ choices: [{ finish_reason: null, index: 0, delta: { content } }] });
+const ROLE_OPENER = event({
+  choices: [
+    {
+      finish_reason: null,
+      index: 0,
+      delta: { role: "assistant", content: null },
+    },
+  ],
+});
+const STOP = event({
+  choices: [{ finish_reason: "stop", index: 0, delta: {} }],
+  timings: { predicted_ms: 12 },
+});
+
+function streamingResponse(chunks, { ok = true, status = 200 } = {}) {
+  const encoder = new TextEncoder();
+  return {
+    ok,
+    status,
+    body: new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+        controller.close();
+      },
+    }),
+    text: async () => chunks.join(""),
+  };
+}
+
+function stubFetch(impl) {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+async function collect(gen) {
+  const out = [];
+  for await (const chunk of gen) out.push(chunk);
+  return out;
+}
+
+async function streamTokens(chunks) {
+  const restore = stubFetch(async () => streamingResponse(chunks));
+  try {
+    return await collect(chatStream(HOST, "test-model", "prompt"));
+  } finally {
+    restore();
+  }
+}
+
+const STREAM_CASES = [
+  {
+    name: "yields each token of an ordinary stream in order",
+    chunks: [
+      ROLE_OPENER,
+      token("Hello"),
+      token(" world"),
+      STOP,
+      "data: [DONE]",
+    ],
+    expected: ["Hello", " world"],
+  },
+  {
+    name: "reassembles an event split across two reads",
+    chunks: ['data: {"choi', 'ces":[{"delta":{"content":"split"}}]}\n\n'],
+    expected: ["split"],
+  },
+  {
+    name: "skips the role-announcing opener rather than yielding a literal null",
+    chunks: [ROLE_OPENER, token("after")],
+    expected: ["after"],
+  },
+  {
+    name: "keeps a single-space token, which a truthiness check would drop",
+    chunks: [token("a"), token(" "), token("b")],
+    expected: ["a", " ", "b"],
+  },
+  {
+    name: "skips the finish_reason chunk carrying an empty delta",
+    chunks: [token("done"), STOP],
+    expected: ["done"],
+  },
+  {
+    name: "reads a [DONE] sentinel that arrives with no trailing blank line",
+    chunks: [token("last"), "data: [DONE]"],
+    expected: ["last"],
+  },
+  {
+    name: "stops at [DONE] and ignores anything sent after it",
+    chunks: [token("kept"), "data: [DONE]\n\n", token("ignored")],
+    expected: ["kept"],
+  },
+  {
+    name: "ignores SSE comment and event-name lines",
+    chunks: [
+      ": keepalive\n\n",
+      'event: message\ndata: {"choices":[{"delta":{"content":"real"}}]}\n\n',
+    ],
+    expected: ["real"],
+  },
+];
+
+for (const { name, chunks, expected } of STREAM_CASES) {
+  test(`chatStream ${name}`, async () => {
+    assert.deepStrictEqual(await streamTokens(chunks), expected);
+  });
+}
+
+test("chatStream throws rather than silently skipping a malformed data payload", async () => {
+  const restore = stubFetch(async () =>
+    streamingResponse([token("fine"), "data: {not json}\n\n"]),
+  );
+  try {
+    await assert.rejects(
+      collect(chatStream(HOST, "test-model", "prompt")),
+      /malformed response for model 'test-model'/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("chatStream sanitizes a server_error's raw parser dump", async () => {
+  const dump =
+    "[json.exception.parse_error.101] parse error at line 1, column 2: syntax error";
+  const restore = stubFetch(async () =>
+    streamingResponse(
+      [
+        JSON.stringify({
+          error: { message: dump, type: "server_error", code: 500 },
+        }),
+      ],
+      { ok: false, status: 500 },
+    ),
+  );
+  try {
+    await assert.rejects(
+      collect(chatStream(HOST, "test-model", "prompt")),
+      (err) => {
+        assert.ok(
+          !err.message.includes("json.exception"),
+          `raw dump leaked to the user: ${err.message}`,
+        );
+        assert.match(
+          err.message,
+          /llama\.cpp failed while handling the request/,
+        );
+        return true;
+      },
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("chatStream surfaces a request-shaped error message as written", async () => {
+  const restore = stubFetch(async () =>
+    streamingResponse(
+      [
+        JSON.stringify({
+          error: {
+            message: "Expected 'messages' to be an array",
+            type: "invalid_request_error",
+            code: 400,
+          },
+        }),
+      ],
+      { ok: false, status: 400 },
+    ),
+  );
+  try {
+    await assert.rejects(
+      collect(chatStream(HOST, "test-model", "prompt")),
+      /Expected 'messages' to be an array/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("chatStream falls back to the status when an error body is not the usual envelope", async () => {
+  const restore = stubFetch(async () =>
+    streamingResponse(["<html>502 Bad Gateway</html>"], {
+      ok: false,
+      status: 502,
+    }),
+  );
+  try {
+    await assert.rejects(
+      collect(chatStream(HOST, "test-model", "prompt")),
+      /502 Bad Gateway/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("chatStream reports a refused connection against the host it tried", async () => {
+  const restore = stubFetch(async () => {
+    throw new TypeError("fetch failed");
+  });
+  try {
+    await assert.rejects(
+      collect(chatStream(HOST, "test-model", "prompt")),
+      /Could not connect to llama\.cpp at http:\/\/127\.0\.0\.1:8080/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("chatStream reports an aborted request as a cancellation", async () => {
+  const restore = stubFetch(async () => {
+    const err = new Error("aborted");
+    err.name = "AbortError";
+    throw err;
+  });
+  try {
+    await assert.rejects(
+      collect(chatStream(HOST, "test-model", "prompt")),
+      /Generation was cancelled/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+// Errors must carry the UserFacingError marker, or toUserMessage() rewrites
+// them through its fallback table, where "could not connect" matches the
+// Ollama entry and a llama.cpp failure would be reported as an Ollama one.
+test("chatStream errors are marked user-facing so they are not remapped", async () => {
+  const restore = stubFetch(async () => {
+    throw new TypeError("fetch failed");
+  });
+  try {
+    await assert.rejects(collect(chatStream(HOST, "m", "p")), (err) => {
+      assert.equal(err.isUserFacing, true);
+      return true;
+    });
+  } finally {
+    restore();
+  }
+});
+
+function routedFetch(routes) {
+  return async (url) => {
+    const { pathname } = new URL(url);
+    const handler = routes[pathname];
+    if (!handler) throw new Error(`unexpected request: ${pathname}`);
+    return handler();
+  };
+}
+
+const ok = (data) => () => ({ ok: true, status: 200, json: async () => data });
+const notFound = () => ({ ok: false, status: 404, json: async () => ({}) });
+const unreachable = () => {
+  throw new TypeError("fetch failed");
+};
+
+const PROPS = { default_generation_settings: { n_ctx: 32768 } };
+const MODELS = {
+  object: "list",
+  data: [
+    {
+      id: "Qwen/Qwen2.5-0.5B-Instruct-GGUF:Q4_K_M",
+      meta: { n_ctx: 16384, n_ctx_train: 32768 },
+    },
+  ],
+};
+
+async function health(routes) {
+  const restore = stubFetch(routedFetch(routes));
+  try {
+    return await checkHealth(HOST, 50);
+  } finally {
+    restore();
+  }
+}
+
+test("checkHealth reports the model and the running context window", async () => {
+  const result = await health({
+    "/health": ok({ status: "ok" }),
+    "/props": ok(PROPS),
+    "/v1/models": ok(MODELS),
+  });
+  assert.deepStrictEqual(result, {
+    connected: true,
+    models: ["Qwen/Qwen2.5-0.5B-Instruct-GGUF:Q4_K_M"],
+    contextTokens: 32768,
+  });
+});
+
+// endpoint_props: false is a real server setting, so this path is reachable in
+// normal use rather than only on a broken server.
+test("checkHealth falls back to /v1/models meta when /props is disabled", async () => {
+  const result = await health({
+    "/health": ok({ status: "ok" }),
+    "/props": notFound,
+    "/v1/models": ok(MODELS),
+  });
+  assert.equal(result.connected, true);
+  assert.equal(result.contextTokens, 16384);
+});
+
+test("checkHealth leaves contextTokens null when neither endpoint reports one", async () => {
+  const result = await health({
+    "/health": ok({ status: "ok" }),
+    "/props": notFound,
+    "/v1/models": ok({ data: [{ id: "some-model" }] }),
+  });
+  assert.equal(result.connected, true);
+  assert.equal(result.contextTokens, null);
+  assert.deepStrictEqual(result.models, ["some-model"]);
+});
+
+test("checkHealth stays connected when both enrichment lookups fail", async () => {
+  const result = await health({
+    "/health": ok({ status: "ok" }),
+    "/props": unreachable,
+    "/v1/models": unreachable,
+  });
+  assert.deepStrictEqual(result, {
+    connected: true,
+    models: [],
+    contextTokens: null,
+  });
+});
+
+test("checkHealth lists every model when a proxy is serving several", async () => {
+  const result = await health({
+    "/health": ok({ status: "ok" }),
+    "/props": notFound,
+    "/v1/models": ok({
+      data: [{ id: "model-a" }, { id: "model-b" }, { id: "model-c" }],
+    }),
+  });
+  assert.deepStrictEqual(result.models, ["model-a", "model-b", "model-c"]);
+});
+
+test("checkHealth reports a non-ok /health as disconnected", async () => {
+  const result = await health({
+    "/health": () => ({ ok: false, status: 503, json: async () => ({}) }),
+  });
+  assert.deepStrictEqual(result, {
+    connected: false,
+    models: [],
+    contextTokens: null,
+  });
+});
+
+test("checkHealth reports an unreachable server as disconnected instead of throwing", async () => {
+  const result = await health({ "/health": unreachable });
+  assert.deepStrictEqual(result, {
+    connected: false,
+    models: [],
+    contextTokens: null,
+  });
+});
+
+test("DEFAULT_CONTEXT_TOKENS is small enough to be safe on an unreported window", () => {
+  assert.equal(DEFAULT_CONTEXT_TOKENS, 8192);
+});

--- a/apogee-extension/tests/engines/llamaCppClient.test.js
+++ b/apogee-extension/tests/engines/llamaCppClient.test.js
@@ -31,7 +31,8 @@ const STOP = event({
 
 function streamingResponse(chunks, { ok = true, status = 200 } = {}) {
   const encoder = new TextEncoder();
-  return {
+  const state = { cancelled: false };
+  const response = {
     ok,
     status,
     body: new ReadableStream({
@@ -39,9 +40,14 @@ function streamingResponse(chunks, { ok = true, status = 200 } = {}) {
         for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
         controller.close();
       },
+      cancel() {
+        state.cancelled = true;
+      },
     }),
     text: async () => chunks.join(""),
   };
+  response._state = state;
+  return response;
 }
 
 function stubFetch(impl) {
@@ -324,6 +330,58 @@ test("chatStream explains a rejected API key instead of echoing the server", asy
     await assert.rejects(
       collect(chatStream(HOST, "m", "p", { apiKey: "wrong" })),
       /rejected the API key.*--api-key/s,
+    );
+  } finally {
+    restore();
+  }
+});
+
+// Cancelling a summary breaks out of the loop partway through. The generator
+// has to release the body then, or the connection is held until the request is
+// garbage collected.
+test("chatStream releases the response body when the consumer stops early", async () => {
+  let response;
+  const restore = stubFetch(async () => {
+    response = streamingResponse([
+      token("one"),
+      token("two"),
+      token("three"),
+      "data: [DONE]",
+    ]);
+    return response;
+  });
+  try {
+    for await (const chunk of chatStream(HOST, "m", "p")) {
+      if (chunk === "one") break;
+    }
+    assert.equal(
+      response._state.cancelled,
+      true,
+      "body was not cancelled, so the connection is held",
+    );
+    assert.equal(response.body.locked, false, "response body left locked");
+  } finally {
+    restore();
+  }
+});
+
+test("chatStream reports a mid-stream error arriving after a 200", async () => {
+  const restore = stubFetch(async () =>
+    streamingResponse([
+      token("partial"),
+      `data: ${JSON.stringify({
+        error: {
+          message: "context window exceeded",
+          type: "invalid_request_error",
+          code: 400,
+        },
+      })}\n\n`,
+    ]),
+  );
+  try {
+    await assert.rejects(
+      collect(chatStream(HOST, "test-model", "prompt")),
+      /context window exceeded/,
     );
   } finally {
     restore();

--- a/apogee-extension/tests/engines/llamaCppClient.test.js
+++ b/apogee-extension/tests/engines/llamaCppClient.test.js
@@ -261,9 +261,79 @@ test("chatStream errors are marked user-facing so they are not remapped", async 
   }
 });
 
-function routedFetch(routes) {
-  return async (url) => {
+test("chatStream sends no Authorization header when no key is configured", async () => {
+  let sent;
+  const restore = stubFetch(async (_url, init) => {
+    sent = init.headers;
+    return streamingResponse([token("hi"), "data: [DONE]"]);
+  });
+  try {
+    await collect(chatStream(HOST, "m", "p"));
+    assert.equal(sent.Authorization, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test("chatStream sends the API key as a bearer token when one is set", async () => {
+  let sent;
+  const restore = stubFetch(async (_url, init) => {
+    sent = init.headers;
+    return streamingResponse([token("hi"), "data: [DONE]"]);
+  });
+  try {
+    await collect(chatStream(HOST, "m", "p", { apiKey: "secret123" }));
+    assert.equal(sent.Authorization, "Bearer secret123");
+  } finally {
+    restore();
+  }
+});
+
+// A key that is only whitespace is the same as no key, and sending
+// "Bearer    " would turn an unauthenticated server into a 401.
+test("chatStream treats a blank API key as no key at all", async () => {
+  let sent;
+  const restore = stubFetch(async (_url, init) => {
+    sent = init.headers;
+    return streamingResponse([token("hi"), "data: [DONE]"]);
+  });
+  try {
+    await collect(chatStream(HOST, "m", "p", { apiKey: "   " }));
+    assert.equal(sent.Authorization, undefined);
+  } finally {
+    restore();
+  }
+});
+
+test("chatStream explains a rejected API key instead of echoing the server", async () => {
+  const restore = stubFetch(async () =>
+    streamingResponse(
+      [
+        JSON.stringify({
+          error: {
+            message: "Invalid API Key",
+            type: "authentication_error",
+            code: 401,
+          },
+        }),
+      ],
+      { ok: false, status: 401 },
+    ),
+  );
+  try {
+    await assert.rejects(
+      collect(chatStream(HOST, "m", "p", { apiKey: "wrong" })),
+      /rejected the API key.*--api-key/s,
+    );
+  } finally {
+    restore();
+  }
+});
+
+function routedFetch(routes, onRequest) {
+  return async (url, init) => {
     const { pathname } = new URL(url);
+    onRequest?.(pathname, init);
     const handler = routes[pathname];
     if (!handler) throw new Error(`unexpected request: ${pathname}`);
     return handler();
@@ -374,6 +444,32 @@ test("checkHealth reports an unreachable server as disconnected instead of throw
     models: [],
     contextTokens: null,
   });
+});
+
+// Which endpoints --api-key guards has changed between llama-server versions,
+// so the key goes on all three rather than a guessed subset.
+test("checkHealth authenticates every lookup, not just the guarded ones", async () => {
+  const seen = new Map();
+  const restore = stubFetch(
+    routedFetch(
+      {
+        "/health": ok({ status: "ok" }),
+        "/props": ok(PROPS),
+        "/v1/models": ok(MODELS),
+      },
+      (pathname, init) => seen.set(pathname, init?.headers?.Authorization),
+    ),
+  );
+  try {
+    await checkHealth(HOST, 50, "secret123");
+  } finally {
+    restore();
+  }
+  assert.deepStrictEqual([...seen.entries()].sort(), [
+    ["/health", "Bearer secret123"],
+    ["/props", "Bearer secret123"],
+    ["/v1/models", "Bearer secret123"],
+  ]);
 });
 
 test("DEFAULT_CONTEXT_TOKENS is small enough to be safe on an unreported window", () => {

--- a/apogee-extension/tests/engines/llamaCppClient.test.js
+++ b/apogee-extension/tests/engines/llamaCppClient.test.js
@@ -288,8 +288,8 @@ test("chatStream sends the API key as a bearer token when one is set", async () 
     return streamingResponse([token("hi"), "data: [DONE]"]);
   });
   try {
-    await collect(chatStream(HOST, "m", "p", { apiKey: "secret123" }));
-    assert.equal(sent.Authorization, "Bearer secret123");
+    await collect(chatStream(HOST, "m", "p", { apiKey: "test-api-key" }));
+    assert.equal(sent.Authorization, "Bearer test-api-key");
   } finally {
     restore();
   }
@@ -542,14 +542,14 @@ test("checkHealth authenticates every lookup, not just the guarded ones", async 
     ),
   );
   try {
-    await checkHealth(HOST, 50, "secret123");
+    await checkHealth(HOST, 50, "test-api-key");
   } finally {
     restore();
   }
   assert.deepStrictEqual([...seen.entries()].sort(), [
-    ["/health", "Bearer secret123"],
-    ["/props", "Bearer secret123"],
-    ["/v1/models", "Bearer secret123"],
+    ["/health", "Bearer test-api-key"],
+    ["/props", "Bearer test-api-key"],
+    ["/v1/models", "Bearer test-api-key"],
   ]);
 });
 

--- a/apogee-extension/tests/engines/llamaCppClient.test.js
+++ b/apogee-extension/tests/engines/llamaCppClient.test.js
@@ -415,6 +415,29 @@ test("checkHealth stays connected when both enrichment lookups fail", async () =
   });
 });
 
+// Verified against b10603: /health is public but /props and /v1/models are
+// both guarded, so a bad key looks like a reachable server with nothing on it.
+// The UI needs that pair to tell a bad key from an idle server.
+test("checkHealth with a rejected key stays connected but reports nothing", async () => {
+  const rejected = () => ({
+    ok: false,
+    status: 401,
+    json: async () => ({
+      error: { message: "Invalid API Key", type: "authentication_error" },
+    }),
+  });
+  const result = await health({
+    "/health": ok({ status: "ok" }),
+    "/props": rejected,
+    "/v1/models": rejected,
+  });
+  assert.deepStrictEqual(result, {
+    connected: true,
+    models: [],
+    contextTokens: null,
+  });
+});
+
 test("checkHealth lists every model when a proxy is serving several", async () => {
   const result = await health({
     "/health": ok({ status: "ok" }),

--- a/apogee-extension/tests/engines/modelLimits.test.js
+++ b/apogee-extension/tests/engines/modelLimits.test.js
@@ -43,3 +43,44 @@ test("getMaxChunks fans Transformers.js models out into far fewer chunks", () =>
   assert.equal(getMaxChunks("Qwen2.5-1.5B-Instruct-q4f16_1-MLC"), 12);
   assert.equal(getMaxChunks("llama3.1:8b"), 12);
 });
+
+// A llama.cpp server takes its context window from its own -c launch flag, so
+// the model name cannot imply it. A caller that has asked the server what it
+// is running passes the answer, and it has to beat every name-based guess.
+test("getMaxChunkChars prefers a reported context window over the model name", () => {
+  // llama3.1 would otherwise be read as a 128k model and capped to 24000.
+  assert.equal(getMaxChunkChars("llama3.1:8b"), 87808);
+  assert.equal(getMaxChunkChars("llama3.1:8b", 4096), 8192);
+});
+
+test("getMaxChunkChars applies a reported window to every model-name shape", () => {
+  for (const model of [
+    "llama3.1:8b",
+    "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
+    TRANSFORMERS_MODELS[0].id,
+    "Qwen/Qwen2.5-0.5B-Instruct-GGUF:Q4_K_M",
+    "",
+  ]) {
+    assert.equal(getMaxChunkChars(model, 4096), 8192);
+  }
+});
+
+test("getMaxChunkChars still caps a large reported window at the practical max", () => {
+  assert.equal(getMaxChunkChars("some-model", 32768), 87808);
+  assert.equal(getMaxChunkChars("some-model", 1000000), 87808);
+});
+
+test("getMaxChunkChars keeps a floor under a tiny reported window", () => {
+  assert.equal(getMaxChunkChars("some-model", 1024), 2048);
+});
+
+// Everything that does not pass an override has to behave exactly as before.
+test("getMaxChunkChars ignores an absent or unusable override", () => {
+  for (const override of [undefined, null, 0, -1, NaN, Infinity, "4096", {}]) {
+    assert.equal(
+      getMaxChunkChars("llama3.1:8b", override),
+      getMaxChunkChars("llama3.1:8b"),
+      `override ${String(override)} should have been ignored`,
+    );
+  }
+});


### PR DESCRIPTION
Adds lib/engines/llamaCppClient.js, exposing the same two-function shape as
ollamaClient.js (chatStream, checkHealth) so it is substitutable wherever that
one is used. Nothing imports it yet; the wiring lands in later PRs.

chatStream targets llama-server's OpenAI-compatible /v1/chat/completions and
parses SSE rather than Ollama's NDJSON. Two behaviours were found against a
live server (build b10603-c060ca974) and are handled explicitly:

- The opening chunk announces the assistant role with `content: null`, so the
  guard checks the type rather than definedness; a `!== undefined` test would
  emit the literal string "null". The same check skips the closing
  finish_reason chunk while still passing a single-space token through, which
  a truthiness test would drop.
- `data: [DONE]` arrives with no trailing blank line, so the buffer is flushed
  once the reader finishes. Consuming only complete `\n\n` events leaves the
  sentinel stranded.

checkHealth treats /health as the sole test of reachability; /props and
/v1/models only enrich the result and cannot flip it, so a server with
endpoint_props disabled still reports as connected. The running context window
is read from /props, falling back to /v1/models meta.n_ctx, and is left null
when neither reports one -- llama-server's window comes from its -c flag, so a
model name cannot be used to infer it.

Errors extend UserFacingError so toUserMessage() does not remap them onto the
Ollama fallback. A server_error's message can be a raw C++ parser dump, so
that case is replaced with a readable line; request-shaped 400/404 messages
are surfaced as written.

Part of #91

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017CSWsUprZEqZvWBLqXvcAy## Summary

<!-- What does this PR change, and why? -->

## Test plan

<!-- How did you verify this? Check the boxes you actually ran. -->

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [ ] Manually exercised the change in a loaded browser extension

## Privacy impact

<!-- Does this add, remove, or change any outbound network request or permission? -->

- [ ] No new outbound network calls
- [ ] Adds/changes a network call (described above, docs updated)

<!-- Permissions and network behaviour are described in four places that must
     agree: apogee-extension/manifest.json, README.md (Privacy & Permissions),
     PRIVACY.md, and store-listing.md (permission justifications). A claim in
     one and not the others is what store reviewers catch. -->

- [ ] Permissions unchanged, or all four of manifest / README / PRIVACY /
      store-listing updated together
