### PR TITLE
feat(engines): register llama.cpp as a selectable provider (PR 4 of 7 planned PRs for #91)

### DIFF
--- a/apogee-extension/lib/constants.js
+++ b/apogee-extension/lib/constants.js
@@ -130,9 +130,17 @@ const DEFAULT_LOCAL_MODEL = "qwen3:8b";
 
 const isFirefox = process.env.TARGET_BROWSER === "firefox";
 
+// llama.cpp is offered on both builds: like Ollama it is a plain fetch to a
+// loopback server, with none of the WebGPU or offscreen-document dependency
+// that keeps WebLLM off Firefox.
 export const PROVIDERS = isFirefox
-  ? { TRANSFORMERS: "transformers", LOCAL: "local" }
-  : { WEBLLM: "webllm", TRANSFORMERS: "transformers", LOCAL: "local" };
+  ? { TRANSFORMERS: "transformers", LOCAL: "local", LLAMACPP: "llamacpp" }
+  : {
+      WEBLLM: "webllm",
+      TRANSFORMERS: "transformers",
+      LOCAL: "local",
+      LLAMACPP: "llamacpp",
+    };
 
 export const DEFAULT_PROVIDER = isFirefox
   ? PROVIDERS.TRANSFORMERS
@@ -140,12 +148,21 @@ export const DEFAULT_PROVIDER = isFirefox
 
 export const DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434";
 
+export const DEFAULT_LLAMACPP_HOST = "http://127.0.0.1:8080";
+
 export const DEFAULT_SETTINGS = {
   provider: DEFAULT_PROVIDER,
   webllmModel: DEFAULT_WEBLLM_MODEL,
   transformersModel: DEFAULT_TRANSFORMERS_MODEL,
   localModel: DEFAULT_LOCAL_MODEL,
   ollamaHost: DEFAULT_OLLAMA_HOST,
+  // llama-server loads one model at launch, so there is no list to pick from
+  // and no sensible default to ship: the name is filled in from the server
+  // once it answers. The API key stays empty unless the server was started
+  // with --api-key, which most are not.
+  llamaHost: DEFAULT_LLAMACPP_HOST,
+  llamaModel: "",
+  llamaApiKey: "",
   responseFormat: "bullets",
   customInstructions: "",
   summaryLanguage: DEFAULT_SUMMARY_LANGUAGE,

--- a/apogee-extension/lib/engines/providers.js
+++ b/apogee-extension/lib/engines/providers.js
@@ -2,6 +2,7 @@ import {
   PROVIDERS,
   DEFAULT_PROVIDER,
   DEFAULT_OLLAMA_HOST,
+  DEFAULT_LLAMACPP_HOST,
 } from "../constants.js";
 
 function sendToServiceWorker(message) {
@@ -118,6 +119,18 @@ async function startTransformersStream(action, payload) {
   const { streamId } = await sendToServiceWorker({
     target: "service-worker",
     action: "transformers-stream",
+    payload: { action, ...payload },
+  });
+  if (!streamId) {
+    throw new Error("No streamId returned from service worker");
+  }
+  return { streamId, stream: attachToStream(streamId) };
+}
+
+async function startLlamaCppStream(action, payload) {
+  const { streamId } = await sendToServiceWorker({
+    target: "service-worker",
+    action: "llamacpp-stream",
     payload: { action, ...payload },
   });
   if (!streamId) {
@@ -281,6 +294,70 @@ class DirectOllamaProvider {
   }
 }
 
+class DirectLlamaCppProvider {
+  constructor(model, host, apiKey) {
+    this.model = model;
+    this.host = (host || DEFAULT_LLAMACPP_HOST).replace(/\/+$/, "");
+    this.apiKey = apiKey || "";
+  }
+
+  summarize({
+    title,
+    url,
+    content,
+    mode,
+    type,
+    finalize,
+    language,
+    translationEngine,
+  }) {
+    return startLlamaCppStream("summarize", {
+      title,
+      url,
+      content,
+      mode,
+      type,
+      model: this.model,
+      host: this.host,
+      apiKey: this.apiKey,
+      finalize,
+      language,
+      translationEngine,
+    });
+  }
+
+  ask({ title, url, content, question, language, translationEngine }) {
+    return startLlamaCppStream("ask", {
+      title,
+      url,
+      content,
+      question,
+      model: this.model,
+      host: this.host,
+      apiKey: this.apiKey,
+      language,
+      translationEngine,
+    });
+  }
+
+  // `contextTokens` rides along because llama-server reports the window it is
+  // actually running, which no model name can imply. Null means it did not
+  // say, not that it is unlimited.
+  async checkReady() {
+    const response = await sendToServiceWorker({
+      target: "service-worker",
+      action: "llamacpp-status",
+      payload: { host: this.host, apiKey: this.apiKey },
+    });
+    return {
+      ready: response?.connected === true,
+      models: response?.models || [],
+      contextTokens: response?.contextTokens ?? null,
+      error: response?.error,
+    };
+  }
+}
+
 export function getProviderType(settings) {
   const provider = settings.provider;
   if (Object.values(PROVIDERS).includes(provider)) return provider;
@@ -289,6 +366,7 @@ export function getProviderType(settings) {
 
 export function getModelForSettings(settings) {
   if (settings.provider === PROVIDERS.LOCAL) return settings.localModel;
+  if (settings.provider === PROVIDERS.LLAMACPP) return settings.llamaModel;
   if (settings.provider === PROVIDERS.TRANSFORMERS) {
     return settings.transformersModel;
   }
@@ -299,6 +377,13 @@ export function getProvider(settings) {
   const type = getProviderType(settings);
   if (type === PROVIDERS.LOCAL) {
     return new DirectOllamaProvider(settings.localModel, settings.ollamaHost);
+  }
+  if (type === PROVIDERS.LLAMACPP) {
+    return new DirectLlamaCppProvider(
+      settings.llamaModel,
+      settings.llamaHost,
+      settings.llamaApiKey,
+    );
   }
   if (type === PROVIDERS.TRANSFORMERS) {
     return new TransformersProvider(settings.transformersModel);

--- a/apogee-extension/tests/engines/providers.test.js
+++ b/apogee-extension/tests/engines/providers.test.js
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import {
+  getProvider,
+  getProviderType,
+  getModelForSettings,
+} from "../../lib/engines/providers.js";
+import {
+  PROVIDERS,
+  DEFAULT_PROVIDER,
+  DEFAULT_SETTINGS,
+  DEFAULT_LLAMACPP_HOST,
+} from "../../lib/constants.js";
+
+const settings = (overrides) => ({ ...DEFAULT_SETTINGS, ...overrides });
+
+test("every provider in the registry resolves to its own implementation", () => {
+  const seen = new Map();
+  for (const type of Object.values(PROVIDERS)) {
+    const provider = getProvider(settings({ provider: type }));
+    seen.set(type, provider.constructor.name);
+  }
+  // Each provider must get its own class; two mapping to the same one would
+  // mean a missing branch in getProvider silently falling through.
+  assert.equal(
+    new Set(seen.values()).size,
+    seen.size,
+    `providers collapsed onto the same class: ${JSON.stringify([...seen])}`,
+  );
+  assert.equal(seen.get(PROVIDERS.LLAMACPP), "DirectLlamaCppProvider");
+});
+
+test("getProviderType passes a known provider through and rejects anything else", () => {
+  assert.equal(
+    getProviderType(settings({ provider: PROVIDERS.LLAMACPP })),
+    PROVIDERS.LLAMACPP,
+  );
+  assert.equal(
+    getProviderType(settings({ provider: "nonsense" })),
+    DEFAULT_PROVIDER,
+  );
+  assert.equal(
+    getProviderType(settings({ provider: undefined })),
+    DEFAULT_PROVIDER,
+  );
+});
+
+// Each provider reads its model from its own settings key. Reading the wrong
+// one would send an empty or foreign model name to the server, and would also
+// poison the summary cache key, which is built from this value.
+test("getModelForSettings reads each provider's own model key", () => {
+  const configured = settings({
+    webllmModel: "webllm-one",
+    transformersModel: "transformers-one",
+    localModel: "ollama-one",
+    llamaModel: "llamacpp-one",
+  });
+  assert.equal(
+    getModelForSettings({ ...configured, provider: PROVIDERS.LLAMACPP }),
+    "llamacpp-one",
+  );
+  assert.equal(
+    getModelForSettings({ ...configured, provider: PROVIDERS.LOCAL }),
+    "ollama-one",
+  );
+  assert.equal(
+    getModelForSettings({ ...configured, provider: PROVIDERS.TRANSFORMERS }),
+    "transformers-one",
+  );
+});
+
+test("the llama.cpp provider carries the configured host, model and key", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LLAMACPP,
+      llamaHost: "http://localhost:9999",
+      llamaModel: "some-model.gguf",
+      llamaApiKey: "test-api-key",
+    }),
+  );
+  assert.equal(provider.host, "http://localhost:9999");
+  assert.equal(provider.model, "some-model.gguf");
+  assert.equal(provider.apiKey, "test-api-key");
+});
+
+test("the llama.cpp provider falls back to the default host and an absent key", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LLAMACPP,
+      llamaHost: "",
+      llamaApiKey: undefined,
+    }),
+  );
+  assert.equal(provider.host, DEFAULT_LLAMACPP_HOST);
+  assert.equal(provider.apiKey, "");
+});
+
+// A trailing slash would produce "http://host//v1/chat/completions".
+test("the llama.cpp provider strips trailing slashes from the host", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LLAMACPP,
+      llamaHost: "http://127.0.0.1:8080///",
+    }),
+  );
+  assert.equal(provider.host, "http://127.0.0.1:8080");
+});
+
+test("llama.cpp settings defaults are present and inert", () => {
+  assert.equal(DEFAULT_SETTINGS.llamaHost, DEFAULT_LLAMACPP_HOST);
+  // Empty until the server is asked what it is serving.
+  assert.equal(DEFAULT_SETTINGS.llamaModel, "");
+  assert.equal(DEFAULT_SETTINGS.llamaApiKey, "");
+  // Adding a provider must not change which one users get by default.
+  assert.notEqual(DEFAULT_PROVIDER, PROVIDERS.LLAMACPP);
+});
+
+test("adding llama.cpp left the Ollama provider untouched", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LOCAL,
+      localModel: "qwen3:8b",
+      ollamaHost: "http://127.0.0.1:11434",
+    }),
+  );
+  assert.equal(provider.constructor.name, "DirectOllamaProvider");
+  assert.equal(provider.host, "http://127.0.0.1:11434");
+  assert.equal(provider.model, "qwen3:8b");
+});


### PR DESCRIPTION
## Summary

## Previously in this series

**PR 1**
Added `lib/engines/llamaCppClient.js`, the HTTP client for llama-server. Exposes `chatStream` (SSE parsing against `/v1/chat/completions`) and `checkHealth` (`/health` for reachability, `/v1/models` for the model name, `/props` for the context window). Handles two wire-format quirks found by testing against a live server: the opening chunk sends `content: null`, and `[DONE]` arrives with no trailing blank line. Ships unused — nothing imports it.

**PR 2**
Parameterized the loopback streaming path in `background/service-worker.js`. `startOllamaStream` became `startLocalHttpStream(streamId, payload, client = OLLAMA_PROVIDER)`, with the same treatment for the suggestions helper and the host validator. Of its ~110 lines only three were Ollama-specific, so a second provider now needs no cloned copy. Pure refactor — every existing call site passes no client, and the four error strings `ERROR.md` documents verbatim are reproduced exactly. Regression-tested against a real Ollama.

**PR 3**
Gave `getMaxChunkChars` an optional second argument for a context window the server reports. Necessary because llama-server takes its window from its own `-c` launch flag, so the same GGUF serves 4096 tokens or 32768 with an identical name — measured on b10603, `/props` reported `n_ctx: 4096` where `n_ctx_train` was 32768. Without it, a file named for a 128k model run with `-c 4096` gets chunks ten times too large. Callers passing nothing keep the existing name-based behavior.


## This PR

Registers llama.cpp in the provider registry: `PROVIDERS.LLAMACPP` plus a `DirectLlamaCppProvider` implementing the same `summarize` / `ask` / `checkReady` shape as the other three, so nothing outside the registry branches on which provider is active.

Offered on both builds — like Ollama it's a plain fetch to a loopback server, with none of the WebGPU or offscreen-document dependency that keeps WebLLM off Firefox.

Three settings keys, all inert by default:

| Key | Default | Why |
| --- | --- | --- |
| `llamaHost` | `http://127.0.0.1:8080` | llama-server's default port |
| `llamaModel` | `""` | llama-server loads one model at launch — no list to choose from, no sensible default to ship. Filled in from the server once it answers. |
| `llamaApiKey` | `""` | Only servers started with `--api-key` need one |

`checkReady` passes `contextTokens` through from PR 1's client — that's the value PR 3's override consumes.

## Tests

8 new tests covering the registry rather than the classes:

- Every provider resolves to a distinct implementation — a missing branch in `getProvider` would silently fall through to WebLLM, which this catches.
- Each provider reads its own model key. This matters beyond the request: `getModelForSettings` also feeds `getSummaryCacheKey`, so reading the wrong key would let two different models share cached output.
- Host defaulting, trailing-slash stripping, and that `DEFAULT_PROVIDER` is unchanged.
- Verified under both the Chromium and Firefox provider shapes, since `PROVIDERS` differs by build target.

## Still inert

Nothing routes `llamacpp-stream` or `llamacpp-status` yet, so selecting this provider does nothing until PR 5, and there's no UI to select it until PR 6.

(Includes `llamaApiKey`, carrying forward the `--api-key` support from PR 1. Happy to drop it if you'd rather that wait.)

Part of #91

<!-- What does this PR change, and why? -->

## Test plan

<!-- How did you verify this? Check the boxes you actually ran. -->

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [ ] Manually exercised the change in a loaded browser extension

## Privacy impact

<!-- Does this add, remove, or change any outbound network request or permission? -->

- [x] No new outbound network calls
- [ ] Adds/changes a network call (described above, docs updated)

<!-- Permissions and network behaviour are described in four places that must
     agree: apogee-extension/manifest.json, README.md (Privacy & Permissions),
     PRIVACY.md, and store-listing.md (permission justifications). A claim in
     one and not the others is what store reviewers catch. -->

- [x] Permissions unchanged, or all four of manifest / README / PRIVACY /
      store-listing updated together
