### PR TITLE
feat(background): route llama.cpp jobs through the service worker (PR 5 of 7 planned PRs for #91)

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -412,6 +412,7 @@ function createBufferedStream(streamId, { finalize, model, title, url }) {
     text: "",
     done: false,
     error: null,
+    errorUserFacing: false,
     cancelled: false,
     subscribers: new Set(),
     controller: new AbortController(),
@@ -424,6 +425,7 @@ function createBufferedStream(streamId, { finalize, model, title, url }) {
     if (msg.type === "done") stream.done = true;
     if (msg.type === "error") {
       stream.error = msg.error;
+      stream.errorUserFacing = !!msg.userFacing;
       stream.done = true;
     }
     broadcastToStream(stream, msg);
@@ -472,7 +474,11 @@ async function startLocalHttpStream(
   try {
     validHost = validateLoopbackHost(host, client.label);
   } catch (err) {
-    finish({ type: "error", error: err.message });
+    finish({
+      type: "error",
+      error: err.message,
+      userFacing: !!err?.isUserFacing,
+    });
     return;
   }
 
@@ -573,7 +579,11 @@ async function startLocalHttpStream(
     }
     finish({ type: "done" });
   } catch (err) {
-    finish({ type: "error", error: err.message });
+    finish({
+      type: "error",
+      error: err.message,
+      userFacing: !!err?.isUserFacing,
+    });
   }
 }
 
@@ -699,7 +709,11 @@ async function startTransformersStream(
     });
     finish({ type: "done" });
   } catch (err) {
-    finish({ type: "error", error: err?.message || String(err) });
+    finish({
+      type: "error",
+      error: err?.message || String(err),
+      userFacing: !!err?.isUserFacing,
+    });
   }
 }
 
@@ -1455,7 +1469,11 @@ chrome.runtime.onConnect.addListener((port) => {
     } catch {}
   } else if (stream.error) {
     try {
-      popupPort.postMessage({ type: "error", error: stream.error });
+      popupPort.postMessage({
+        type: "error",
+        error: stream.error,
+        userFacing: stream.errorUserFacing,
+      });
     } catch {}
   } else if (stream.done) {
     try {

--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -6,6 +6,13 @@ import {
 } from "../lib/language/languageOutput.js";
 import { makeOpusTranslateFn } from "../lib/language/opusTranslateEngine.js";
 import { chatStream, checkHealth } from "../lib/engines/ollamaClient.js";
+import {
+  chatStream as llamaChatStream,
+  checkHealth as llamaCheckHealth,
+  DEFAULT_CONTEXT_TOKENS as LLAMACPP_DEFAULT_CONTEXT_TOKENS,
+} from "../lib/engines/llamaCppClient.js";
+import { getMaxChunkChars } from "../lib/engines/modelLimits.js";
+import { chunkBySections } from "../lib/summarize/sections.js";
 import { errorHelpUrl } from "../lib/util/errorHelp.js";
 import { toUserMessage } from "../lib/util/userError.js";
 import { hasHostPermissions } from "../lib/util/permissions.js";
@@ -357,6 +364,19 @@ const OLLAMA_PROVIDER = {
   streamKind: "ollama-stream",
   chatStream,
 };
+
+// llama-server reports the context window it is actually running, which comes
+// from its own -c launch flag and so cannot be read off the model name. Ollama
+// has no equivalent, which is why only this provider supplies the hook.
+const LLAMACPP_PROVIDER = {
+  label: "llama.cpp",
+  streamKind: "llamacpp-stream",
+  chatStream: llamaChatStream,
+  async getContextTokens(host, apiKey) {
+    const health = await llamaCheckHealth(host, 3000, apiKey);
+    return health.contextTokens ?? LLAMACPP_DEFAULT_CONTEXT_TOKENS;
+  },
+};
 async function getRelevantAskContent(content, question) {
   if (!hasOffscreenAPI) {
     try {
@@ -437,6 +457,7 @@ async function startLocalHttpStream(
     finalize,
     language,
     translationEngine,
+    apiKey,
   },
   client = OLLAMA_PROVIDER,
 ) {
@@ -456,6 +477,26 @@ async function startLocalHttpStream(
   }
 
   const { customInstructions } = await getSettings();
+
+  // Ollama's client ignores the extra option; llama.cpp's uses it when the
+  // server was started with --api-key.
+  const chatStreamFn = (h, m, p, opts) =>
+    client.chatStream(h, m, p, { ...opts, apiKey });
+
+  // Only a provider that can report its own window gets an explicit chunk
+  // size; everyone else keeps the model-name inference in getMaxChunkChars.
+  let chunkTextFn;
+  if (client.getContextTokens) {
+    try {
+      const contextTokens = await client.getContextTokens(validHost, apiKey);
+      const chunkChars = getMaxChunkChars(model, contextTokens);
+      chunkTextFn = (text) => chunkBySections(text, chunkChars);
+    } catch (err) {
+      // A window we could not read is not worth failing the job over: fall
+      // through to the name-based estimate the other providers use.
+      console.error("llama.cpp context-window lookup failed:", err);
+    }
+  }
 
   let longNote = "";
   const reportProgress = (text) => {
@@ -490,7 +531,8 @@ async function startLocalHttpStream(
           signal: stream.controller.signal,
         },
         {
-          chatStreamFn: client.chatStream,
+          chatStreamFn,
+          ...(chunkTextFn ? { chunkTextFn } : {}),
           translateFn,
           onProgress: (p) => {
             if (p.stage === "truncated") {
@@ -515,7 +557,7 @@ async function startLocalHttpStream(
         buildAnswerPrompt(title, url, relevantContent, question),
         customInstructions,
       );
-      const chat = (p, opts) => client.chatStream(validHost, model, p, opts);
+      const chat = (p, opts) => chatStreamFn(validHost, model, p, opts);
       generator = streamInTargetLanguage(
         chat,
         prompt,
@@ -811,6 +853,8 @@ async function runBackgroundSummarize(
   if (providerType === PROVIDERS.LOCAL) {
     streamId = nextStreamId("ollama");
     startLocalHttpStream(streamId, { ...common, host: settings.ollamaHost });
+  } else if (providerType === PROVIDERS.LLAMACPP) {
+    streamId = nextStreamId("llamacpp");
   } else if (providerType === PROVIDERS.TRANSFORMERS) {
     streamId = nextStreamId("transformers");
   } else {
@@ -840,6 +884,16 @@ async function runBackgroundSummarize(
 
   if (providerType === PROVIDERS.LOCAL) {
     startLocalHttpStream(streamId, { ...common, host: settings.ollamaHost });
+  } else if (providerType === PROVIDERS.LLAMACPP) {
+    startLocalHttpStream(
+      streamId,
+      {
+        ...common,
+        host: settings.llamaHost,
+        apiKey: settings.llamaApiKey,
+      },
+      LLAMACPP_PROVIDER,
+    );
   } else if (providerType === PROVIDERS.TRANSFORMERS) {
     startTransformersStream(streamId, common);
   } else {
@@ -1056,10 +1110,12 @@ async function generateLocalSuggestions(
   model,
   { title, url, summary, language, translationEngine },
   client = OLLAMA_PROVIDER,
+  apiKey = "",
 ) {
   const validHost = validateLoopbackHost(host, client.label);
   const prompt = buildSuggestQuestionsPrompt(title, url, summary);
-  const chat = (p, opts) => client.chatStream(validHost, model, p, opts);
+  const chat = (p, opts) =>
+    client.chatStream(validHost, model, p, { ...opts, apiKey });
   const qLanguage = await resolveEffectiveLanguage(summary, language);
   const translateFn =
     translationEngine === TRANSLATION_ENGINES.OPUS
@@ -1094,7 +1150,16 @@ async function runSuggestQuestionsJob(payload) {
   try {
     let questions = [];
     try {
-      if (providerType === PROVIDERS.LOCAL) {
+      if (providerType === PROVIDERS.LLAMACPP) {
+        const { llamaHost, llamaApiKey } = await getSettings();
+        questions = await generateLocalSuggestions(
+          llamaHost,
+          model,
+          { title, url, summary, language },
+          LLAMACPP_PROVIDER,
+          llamaApiKey,
+        );
+      } else if (providerType === PROVIDERS.LOCAL) {
         questions = await generateLocalSuggestions(host, model, {
           title,
           url,
@@ -1547,6 +1612,46 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           await recordPopupSummaryStream(payload, streamId);
           startLocalHttpStream(streamId, payload);
           sendResponse({ streamId });
+          break;
+        }
+
+        case "llamacpp-stream": {
+          const streamId = nextStreamId("llamacpp");
+          const settings = await getSettings();
+          const trustedFinalize =
+            message.payload?.action === "summarize" || message.payload?.finalize
+              ? await buildTrustedFinalize(message.payload)
+              : null;
+          const payload = {
+            ...message.payload,
+            ...(trustedFinalize ? { finalize: trustedFinalize } : {}),
+            host: settings.llamaHost,
+            apiKey: settings.llamaApiKey,
+          };
+          await recordPopupSummaryStream(payload, streamId);
+          startLocalHttpStream(streamId, payload, LLAMACPP_PROVIDER);
+          sendResponse({ streamId });
+          break;
+        }
+
+        case "llamacpp-status": {
+          const { llamaHost, llamaApiKey } = await getSettings();
+          let validHost;
+          try {
+            validHost = validateLoopbackHost(
+              llamaHost,
+              LLAMACPP_PROVIDER.label,
+            );
+          } catch {
+            sendResponse({
+              connected: false,
+              models: [],
+              contextTokens: null,
+            });
+            break;
+          }
+          const response = await llamaCheckHealth(validHost, 3000, llamaApiKey);
+          sendResponse(response);
           break;
         }
 

--- a/apogee-extension/lib/constants.js
+++ b/apogee-extension/lib/constants.js
@@ -130,9 +130,17 @@ const DEFAULT_LOCAL_MODEL = "qwen3:8b";
 
 const isFirefox = process.env.TARGET_BROWSER === "firefox";
 
+// llama.cpp is offered on both builds: like Ollama it is a plain fetch to a
+// loopback server, with none of the WebGPU or offscreen-document dependency
+// that keeps WebLLM off Firefox.
 export const PROVIDERS = isFirefox
-  ? { TRANSFORMERS: "transformers", LOCAL: "local" }
-  : { WEBLLM: "webllm", TRANSFORMERS: "transformers", LOCAL: "local" };
+  ? { TRANSFORMERS: "transformers", LOCAL: "local", LLAMACPP: "llamacpp" }
+  : {
+      WEBLLM: "webllm",
+      TRANSFORMERS: "transformers",
+      LOCAL: "local",
+      LLAMACPP: "llamacpp",
+    };
 
 export const DEFAULT_PROVIDER = isFirefox
   ? PROVIDERS.TRANSFORMERS
@@ -140,12 +148,21 @@ export const DEFAULT_PROVIDER = isFirefox
 
 export const DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434";
 
+export const DEFAULT_LLAMACPP_HOST = "http://127.0.0.1:8080";
+
 export const DEFAULT_SETTINGS = {
   provider: DEFAULT_PROVIDER,
   webllmModel: DEFAULT_WEBLLM_MODEL,
   transformersModel: DEFAULT_TRANSFORMERS_MODEL,
   localModel: DEFAULT_LOCAL_MODEL,
   ollamaHost: DEFAULT_OLLAMA_HOST,
+  // llama-server loads one model at launch, so there is no list to pick from
+  // and no sensible default to ship: the name is filled in from the server
+  // once it answers. The API key stays empty unless the server was started
+  // with --api-key, which most are not.
+  llamaHost: DEFAULT_LLAMACPP_HOST,
+  llamaModel: "",
+  llamaApiKey: "",
   responseFormat: "bullets",
   customInstructions: "",
   summaryLanguage: DEFAULT_SUMMARY_LANGUAGE,

--- a/apogee-extension/lib/engines/providers.js
+++ b/apogee-extension/lib/engines/providers.js
@@ -2,6 +2,7 @@ import {
   PROVIDERS,
   DEFAULT_PROVIDER,
   DEFAULT_OLLAMA_HOST,
+  DEFAULT_LLAMACPP_HOST,
 } from "../constants.js";
 
 function sendToServiceWorker(message) {
@@ -118,6 +119,18 @@ async function startTransformersStream(action, payload) {
   const { streamId } = await sendToServiceWorker({
     target: "service-worker",
     action: "transformers-stream",
+    payload: { action, ...payload },
+  });
+  if (!streamId) {
+    throw new Error("No streamId returned from service worker");
+  }
+  return { streamId, stream: attachToStream(streamId) };
+}
+
+async function startLlamaCppStream(action, payload) {
+  const { streamId } = await sendToServiceWorker({
+    target: "service-worker",
+    action: "llamacpp-stream",
     payload: { action, ...payload },
   });
   if (!streamId) {
@@ -281,6 +294,70 @@ class DirectOllamaProvider {
   }
 }
 
+class DirectLlamaCppProvider {
+  constructor(model, host, apiKey) {
+    this.model = model;
+    this.host = (host || DEFAULT_LLAMACPP_HOST).replace(/\/+$/, "");
+    this.apiKey = apiKey || "";
+  }
+
+  summarize({
+    title,
+    url,
+    content,
+    mode,
+    type,
+    finalize,
+    language,
+    translationEngine,
+  }) {
+    return startLlamaCppStream("summarize", {
+      title,
+      url,
+      content,
+      mode,
+      type,
+      model: this.model,
+      host: this.host,
+      apiKey: this.apiKey,
+      finalize,
+      language,
+      translationEngine,
+    });
+  }
+
+  ask({ title, url, content, question, language, translationEngine }) {
+    return startLlamaCppStream("ask", {
+      title,
+      url,
+      content,
+      question,
+      model: this.model,
+      host: this.host,
+      apiKey: this.apiKey,
+      language,
+      translationEngine,
+    });
+  }
+
+  // `contextTokens` rides along because llama-server reports the window it is
+  // actually running, which no model name can imply. Null means it did not
+  // say, not that it is unlimited.
+  async checkReady() {
+    const response = await sendToServiceWorker({
+      target: "service-worker",
+      action: "llamacpp-status",
+      payload: { host: this.host, apiKey: this.apiKey },
+    });
+    return {
+      ready: response?.connected === true,
+      models: response?.models || [],
+      contextTokens: response?.contextTokens ?? null,
+      error: response?.error,
+    };
+  }
+}
+
 export function getProviderType(settings) {
   const provider = settings.provider;
   if (Object.values(PROVIDERS).includes(provider)) return provider;
@@ -289,6 +366,7 @@ export function getProviderType(settings) {
 
 export function getModelForSettings(settings) {
   if (settings.provider === PROVIDERS.LOCAL) return settings.localModel;
+  if (settings.provider === PROVIDERS.LLAMACPP) return settings.llamaModel;
   if (settings.provider === PROVIDERS.TRANSFORMERS) {
     return settings.transformersModel;
   }
@@ -299,6 +377,13 @@ export function getProvider(settings) {
   const type = getProviderType(settings);
   if (type === PROVIDERS.LOCAL) {
     return new DirectOllamaProvider(settings.localModel, settings.ollamaHost);
+  }
+  if (type === PROVIDERS.LLAMACPP) {
+    return new DirectLlamaCppProvider(
+      settings.llamaModel,
+      settings.llamaHost,
+      settings.llamaApiKey,
+    );
   }
   if (type === PROVIDERS.TRANSFORMERS) {
     return new TransformersProvider(settings.transformersModel);

--- a/apogee-extension/lib/engines/providers.js
+++ b/apogee-extension/lib/engines/providers.js
@@ -1,3 +1,4 @@
+import { UserFacingError } from "../util/userError.js";
 import {
   PROVIDERS,
   DEFAULT_PROVIDER,
@@ -26,6 +27,7 @@ export async function* attachToStream(streamId) {
   const queue = [];
   let resolvePromise = null;
   let error = null;
+  let errorUserFacing = false;
   let cancelled = false;
   let done = false;
 
@@ -39,6 +41,7 @@ export async function* attachToStream(streamId) {
       done = true;
     } else if (msg.type === "error") {
       error = msg.error || "Unknown error during streaming";
+      errorUserFacing = !!msg.userFacing;
       done = true;
     }
     if (resolvePromise) {
@@ -65,7 +68,7 @@ export async function* attachToStream(streamId) {
       } else if (cancelled) {
         throw new StreamCancelledError("Cancelled.");
       } else if (error) {
-        throw new Error(error);
+        throw errorUserFacing ? new UserFacingError(error) : new Error(error);
       } else if (done) {
         break;
       } else {

--- a/apogee-extension/tests/engines/attachToStream.test.js
+++ b/apogee-extension/tests/engines/attachToStream.test.js
@@ -5,6 +5,7 @@ import {
   attachToStream,
   StreamCancelledError,
 } from "../../lib/engines/providers.js";
+import { toUserMessage } from "../../lib/util/userError.js";
 
 function createFakePort() {
   const listeners = { message: [], disconnect: [] };
@@ -80,4 +81,47 @@ test("attachToStream errors (instead of silently truncating) when the port disco
   port._emitDisconnect();
 
   await assert.rejects(run, /Connection to the model was lost/);
+});
+
+// A message written for the user only survives the port if the marker travels
+// with it. Without this, attachToStream rebuilt a plain Error, toUserMessage
+// fell through to its pattern table, and "Could not connect to llama.cpp..."
+// was rewritten as "Could not connect to Ollama..." because the table matches
+// on "could not connect".
+test("attachToStream keeps an error that was written for the user intact", async () => {
+  const port = createFakePort();
+  globalThis.chrome = { runtime: { connect: () => port } };
+
+  const run = collect(attachToStream("stream-user-facing"));
+  await new Promise((r) => setTimeout(r, 0));
+
+  const written =
+    "Could not connect to llama.cpp at http://127.0.0.1:8080. " +
+    "Is llama-server running and listening on that address?";
+  port._emitMessage({ type: "error", error: written, userFacing: true });
+
+  await assert.rejects(run, (err) => {
+    assert.equal(err.isUserFacing, true, "marker must survive the port");
+    assert.equal(
+      toUserMessage(err),
+      written,
+      "a user-facing message must not be run through the fallback table",
+    );
+    return true;
+  });
+});
+
+test("attachToStream still lets an unmarked error be mapped to a fallback", async () => {
+  const port = createFakePort();
+  globalThis.chrome = { runtime: { connect: () => port } };
+
+  const run = collect(attachToStream("stream-raw"));
+  await new Promise((r) => setTimeout(r, 0));
+
+  port._emitMessage({ type: "error", error: "TypeError: fetch failed" });
+
+  await assert.rejects(run, (err) => {
+    assert.notEqual(err.isUserFacing, true);
+    return true;
+  });
 });

--- a/apogee-extension/tests/engines/providers.test.js
+++ b/apogee-extension/tests/engines/providers.test.js
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import {
+  getProvider,
+  getProviderType,
+  getModelForSettings,
+} from "../../lib/engines/providers.js";
+import {
+  PROVIDERS,
+  DEFAULT_PROVIDER,
+  DEFAULT_SETTINGS,
+  DEFAULT_LLAMACPP_HOST,
+} from "../../lib/constants.js";
+
+const settings = (overrides) => ({ ...DEFAULT_SETTINGS, ...overrides });
+
+test("every provider in the registry resolves to its own implementation", () => {
+  const seen = new Map();
+  for (const type of Object.values(PROVIDERS)) {
+    const provider = getProvider(settings({ provider: type }));
+    seen.set(type, provider.constructor.name);
+  }
+  // Each provider must get its own class; two mapping to the same one would
+  // mean a missing branch in getProvider silently falling through.
+  assert.equal(
+    new Set(seen.values()).size,
+    seen.size,
+    `providers collapsed onto the same class: ${JSON.stringify([...seen])}`,
+  );
+  assert.equal(seen.get(PROVIDERS.LLAMACPP), "DirectLlamaCppProvider");
+});
+
+test("getProviderType passes a known provider through and rejects anything else", () => {
+  assert.equal(
+    getProviderType(settings({ provider: PROVIDERS.LLAMACPP })),
+    PROVIDERS.LLAMACPP,
+  );
+  assert.equal(
+    getProviderType(settings({ provider: "nonsense" })),
+    DEFAULT_PROVIDER,
+  );
+  assert.equal(
+    getProviderType(settings({ provider: undefined })),
+    DEFAULT_PROVIDER,
+  );
+});
+
+// Each provider reads its model from its own settings key. Reading the wrong
+// one would send an empty or foreign model name to the server, and would also
+// poison the summary cache key, which is built from this value.
+test("getModelForSettings reads each provider's own model key", () => {
+  const configured = settings({
+    webllmModel: "webllm-one",
+    transformersModel: "transformers-one",
+    localModel: "ollama-one",
+    llamaModel: "llamacpp-one",
+  });
+  assert.equal(
+    getModelForSettings({ ...configured, provider: PROVIDERS.LLAMACPP }),
+    "llamacpp-one",
+  );
+  assert.equal(
+    getModelForSettings({ ...configured, provider: PROVIDERS.LOCAL }),
+    "ollama-one",
+  );
+  assert.equal(
+    getModelForSettings({ ...configured, provider: PROVIDERS.TRANSFORMERS }),
+    "transformers-one",
+  );
+});
+
+test("the llama.cpp provider carries the configured host, model and key", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LLAMACPP,
+      llamaHost: "http://localhost:9999",
+      llamaModel: "some-model.gguf",
+      llamaApiKey: "test-api-key",
+    }),
+  );
+  assert.equal(provider.host, "http://localhost:9999");
+  assert.equal(provider.model, "some-model.gguf");
+  assert.equal(provider.apiKey, "test-api-key");
+});
+
+test("the llama.cpp provider falls back to the default host and an absent key", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LLAMACPP,
+      llamaHost: "",
+      llamaApiKey: undefined,
+    }),
+  );
+  assert.equal(provider.host, DEFAULT_LLAMACPP_HOST);
+  assert.equal(provider.apiKey, "");
+});
+
+// A trailing slash would produce "http://host//v1/chat/completions".
+test("the llama.cpp provider strips trailing slashes from the host", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LLAMACPP,
+      llamaHost: "http://127.0.0.1:8080///",
+    }),
+  );
+  assert.equal(provider.host, "http://127.0.0.1:8080");
+});
+
+test("llama.cpp settings defaults are present and inert", () => {
+  assert.equal(DEFAULT_SETTINGS.llamaHost, DEFAULT_LLAMACPP_HOST);
+  // Empty until the server is asked what it is serving.
+  assert.equal(DEFAULT_SETTINGS.llamaModel, "");
+  assert.equal(DEFAULT_SETTINGS.llamaApiKey, "");
+  // Adding a provider must not change which one users get by default.
+  assert.notEqual(DEFAULT_PROVIDER, PROVIDERS.LLAMACPP);
+});
+
+test("adding llama.cpp left the Ollama provider untouched", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LOCAL,
+      localModel: "qwen3:8b",
+      ollamaHost: "http://127.0.0.1:11434",
+    }),
+  );
+  assert.equal(provider.constructor.name, "DirectOllamaProvider");
+  assert.equal(provider.host, "http://127.0.0.1:11434");
+  assert.equal(provider.model, "qwen3:8b");
+});


### PR DESCRIPTION
## Summary



## In previous PRs

**PR 1 — llama.cpp client (merged)**
Added `lib/engines/llamaCppClient.js`: `chatStream` (SSE parsing against `/v1/chat/completions`) and `checkHealth` (`/health` for reachability, `/v1/models` for the model name, `/props` for the context window). Handles two wire-format quirks found against a live server — the opening chunk sends `content: null`, and `[DONE]` arrives with no trailing blank line.

**PR 2 — loopback streaming refactor (merged)**
Parameterized the streaming path: `startOllamaStream` → `startLocalHttpStream(streamId, payload, client = OLLAMA_PROVIDER)`, with the same treatment for the suggestions helper and host validator. Only three of its ~110 lines were Ollama-specific. Behavior-preserving, and regression-tested against a real Ollama.

**PR 3 — dynamic context window (merged)**
`getMaxChunkChars(model, contextTokensOverride)`. Needed because llama-server takes its window from its own `-c` flag: measured on b10603, `/props` reported `n_ctx: 4096` where `n_ctx_train` was 32768. Callers passing nothing keep name-based inference.

**PR 4 — provider registration (open — this PR stacks on it)**
`PROVIDERS.LLAMACPP`, the `llamaHost` / `llamaModel` / `llamaApiKey` settings keys, and `DirectLlamaCppProvider`.

## This PR

Wires the client into the streaming path, so selecting the provider actually generates. Adds `llamacpp-stream` and `llamacpp-status` message cases beside the Ollama pair, a `LLAMACPP_PROVIDER` descriptor for `startLocalHttpStream`, and branches in `runBackgroundSummarize` and `runSuggestQuestionsJob`.

Host and API key are read from settings inside the handler rather than taken from the message payload — matching how the Ollama handler was hardened, so the popup can't talk the worker into pointing at a different server.

Two things this provider needs that Ollama doesn't:

- **A context window read from the server.** `LLAMACPP_PROVIDER` exposes `getContextTokens`, and `startLocalHttpStream` turns that into an explicit `chunkTextFn` via `getMaxChunkChars`. A lookup that fails is logged and falls back to the name-based estimate rather than failing the job.
- **An API key**, for servers started with `--api-key`. Bound into the `chatStream` wrapper so it survives the trip through `summarizeText` and `mapReduce`, both of which call `chatStreamFn` with their own options object.

`cancel-stream` and `isOffscreenStream` needed no change — both dispatch on the stream-id prefix, and `llamacpp-` correctly falls to the local `activeStreams` path rather than the offscreen relay.

## No functional change to existing providers

The diff shows 4 removed lines; all four are replacements with a `+` directly above or below:

| Removed | Replaced by | Effect on Ollama |
| --- | --- | --- |
| `chatStreamFn: client.chatStream` | `chatStreamFn` + conditional `chunkTextFn` | Same function; `chunkTextFn` spreads nothing unless the provider can report a window |
| `const chat = … client.chatStream(…)` ×2 | the wrapper / spread `apiKey` | Ollama's client destructures only `{signal, keepAlive, system}`, so `apiKey` is never read |
| `if (providerType === PROVIDERS.LOCAL)` | `else if` after a new branch | Ollama's branch and body byte-identical |

The one technical nuance: options objects now carry an inert `apiKey` key (`undefined` for Ollama). Nothing reads it.


## Two things I ran into, raising separately rather than folding in

`runBackgroundSummarize` dispatches twice for `PROVIDERS.LOCAL` — once where the stream id is assigned, and again after `registerStreamJob`, with the same `streamId`. So an Ollama summary from the context menu or shortcut starts two generations. Predates this PR (came in with the side-panel / Firefox-RAG merge). The llama.cpp arm deliberately only assigns an id in the first block and dispatches in the second, so it isn't replicated.

`PROVIDERS.OLLAMA` is undefined in the multi-tab summarize path — the registry defines `WEBLLM`, `TRANSFORMERS`, `LOCAL`. That comparison is always false, so Ollama users fall through to the WebLLM/offscreen branch. The call beneath it also passes three positional args to `summarizeText`, which takes `(args, options)`.


Part of #91

<!-- What does this PR change, and why? -->

## Test plan

<!-- How did you verify this? Check the boxes you actually ran. -->

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [ ] Manually exercised the change in a loaded browser extension

## Privacy impact

<!-- Does this add, remove, or change any outbound network request or permission? -->

- [x] No new outbound network calls
- [ ] Adds/changes a network call (described above, docs updated)

<!-- Permissions and network behaviour are described in four places that must
     agree: apogee-extension/manifest.json, README.md (Privacy & Permissions),
     PRIVACY.md, and store-listing.md (permission justifications). A claim in
     one and not the others is what store reviewers catch. -->

- [x] Permissions unchanged, or all four of manifest / README / PRIVACY /
      store-listing updated together
