### PR TITLE
 feat(popup): add the llama.cpp provider to Settings (PR 6 of 7 planned PRs for #91)

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -412,6 +412,7 @@ function createBufferedStream(streamId, { finalize, model, title, url }) {
     text: "",
     done: false,
     error: null,
+    errorUserFacing: false,
     cancelled: false,
     subscribers: new Set(),
     controller: new AbortController(),
@@ -424,6 +425,7 @@ function createBufferedStream(streamId, { finalize, model, title, url }) {
     if (msg.type === "done") stream.done = true;
     if (msg.type === "error") {
       stream.error = msg.error;
+      stream.errorUserFacing = !!msg.userFacing;
       stream.done = true;
     }
     broadcastToStream(stream, msg);
@@ -472,7 +474,11 @@ async function startLocalHttpStream(
   try {
     validHost = validateLoopbackHost(host, client.label);
   } catch (err) {
-    finish({ type: "error", error: err.message });
+    finish({
+      type: "error",
+      error: err.message,
+      userFacing: !!err?.isUserFacing,
+    });
     return;
   }
 
@@ -573,7 +579,11 @@ async function startLocalHttpStream(
     }
     finish({ type: "done" });
   } catch (err) {
-    finish({ type: "error", error: err.message });
+    finish({
+      type: "error",
+      error: err.message,
+      userFacing: !!err?.isUserFacing,
+    });
   }
 }
 
@@ -699,7 +709,11 @@ async function startTransformersStream(
     });
     finish({ type: "done" });
   } catch (err) {
-    finish({ type: "error", error: err?.message || String(err) });
+    finish({
+      type: "error",
+      error: err?.message || String(err),
+      userFacing: !!err?.isUserFacing,
+    });
   }
 }
 
@@ -1455,7 +1469,11 @@ chrome.runtime.onConnect.addListener((port) => {
     } catch {}
   } else if (stream.error) {
     try {
-      popupPort.postMessage({ type: "error", error: stream.error });
+      popupPort.postMessage({
+        type: "error",
+        error: stream.error,
+        userFacing: stream.errorUserFacing,
+      });
     } catch {}
   } else if (stream.done) {
     try {

--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -6,6 +6,13 @@ import {
 } from "../lib/language/languageOutput.js";
 import { makeOpusTranslateFn } from "../lib/language/opusTranslateEngine.js";
 import { chatStream, checkHealth } from "../lib/engines/ollamaClient.js";
+import {
+  chatStream as llamaChatStream,
+  checkHealth as llamaCheckHealth,
+  DEFAULT_CONTEXT_TOKENS as LLAMACPP_DEFAULT_CONTEXT_TOKENS,
+} from "../lib/engines/llamaCppClient.js";
+import { getMaxChunkChars } from "../lib/engines/modelLimits.js";
+import { chunkBySections } from "../lib/summarize/sections.js";
 import { errorHelpUrl } from "../lib/util/errorHelp.js";
 import { toUserMessage } from "../lib/util/userError.js";
 import { hasHostPermissions } from "../lib/util/permissions.js";
@@ -357,6 +364,19 @@ const OLLAMA_PROVIDER = {
   streamKind: "ollama-stream",
   chatStream,
 };
+
+// llama-server reports the context window it is actually running, which comes
+// from its own -c launch flag and so cannot be read off the model name. Ollama
+// has no equivalent, which is why only this provider supplies the hook.
+const LLAMACPP_PROVIDER = {
+  label: "llama.cpp",
+  streamKind: "llamacpp-stream",
+  chatStream: llamaChatStream,
+  async getContextTokens(host, apiKey) {
+    const health = await llamaCheckHealth(host, 3000, apiKey);
+    return health.contextTokens ?? LLAMACPP_DEFAULT_CONTEXT_TOKENS;
+  },
+};
 async function getRelevantAskContent(content, question) {
   if (!hasOffscreenAPI) {
     try {
@@ -437,6 +457,7 @@ async function startLocalHttpStream(
     finalize,
     language,
     translationEngine,
+    apiKey,
   },
   client = OLLAMA_PROVIDER,
 ) {
@@ -456,6 +477,26 @@ async function startLocalHttpStream(
   }
 
   const { customInstructions } = await getSettings();
+
+  // Ollama's client ignores the extra option; llama.cpp's uses it when the
+  // server was started with --api-key.
+  const chatStreamFn = (h, m, p, opts) =>
+    client.chatStream(h, m, p, { ...opts, apiKey });
+
+  // Only a provider that can report its own window gets an explicit chunk
+  // size; everyone else keeps the model-name inference in getMaxChunkChars.
+  let chunkTextFn;
+  if (client.getContextTokens) {
+    try {
+      const contextTokens = await client.getContextTokens(validHost, apiKey);
+      const chunkChars = getMaxChunkChars(model, contextTokens);
+      chunkTextFn = (text) => chunkBySections(text, chunkChars);
+    } catch (err) {
+      // A window we could not read is not worth failing the job over: fall
+      // through to the name-based estimate the other providers use.
+      console.error("llama.cpp context-window lookup failed:", err);
+    }
+  }
 
   let longNote = "";
   const reportProgress = (text) => {
@@ -490,7 +531,8 @@ async function startLocalHttpStream(
           signal: stream.controller.signal,
         },
         {
-          chatStreamFn: client.chatStream,
+          chatStreamFn,
+          ...(chunkTextFn ? { chunkTextFn } : {}),
           translateFn,
           onProgress: (p) => {
             if (p.stage === "truncated") {
@@ -515,7 +557,7 @@ async function startLocalHttpStream(
         buildAnswerPrompt(title, url, relevantContent, question),
         customInstructions,
       );
-      const chat = (p, opts) => client.chatStream(validHost, model, p, opts);
+      const chat = (p, opts) => chatStreamFn(validHost, model, p, opts);
       generator = streamInTargetLanguage(
         chat,
         prompt,
@@ -811,6 +853,8 @@ async function runBackgroundSummarize(
   if (providerType === PROVIDERS.LOCAL) {
     streamId = nextStreamId("ollama");
     startLocalHttpStream(streamId, { ...common, host: settings.ollamaHost });
+  } else if (providerType === PROVIDERS.LLAMACPP) {
+    streamId = nextStreamId("llamacpp");
   } else if (providerType === PROVIDERS.TRANSFORMERS) {
     streamId = nextStreamId("transformers");
   } else {
@@ -840,6 +884,16 @@ async function runBackgroundSummarize(
 
   if (providerType === PROVIDERS.LOCAL) {
     startLocalHttpStream(streamId, { ...common, host: settings.ollamaHost });
+  } else if (providerType === PROVIDERS.LLAMACPP) {
+    startLocalHttpStream(
+      streamId,
+      {
+        ...common,
+        host: settings.llamaHost,
+        apiKey: settings.llamaApiKey,
+      },
+      LLAMACPP_PROVIDER,
+    );
   } else if (providerType === PROVIDERS.TRANSFORMERS) {
     startTransformersStream(streamId, common);
   } else {
@@ -1056,10 +1110,12 @@ async function generateLocalSuggestions(
   model,
   { title, url, summary, language, translationEngine },
   client = OLLAMA_PROVIDER,
+  apiKey = "",
 ) {
   const validHost = validateLoopbackHost(host, client.label);
   const prompt = buildSuggestQuestionsPrompt(title, url, summary);
-  const chat = (p, opts) => client.chatStream(validHost, model, p, opts);
+  const chat = (p, opts) =>
+    client.chatStream(validHost, model, p, { ...opts, apiKey });
   const qLanguage = await resolveEffectiveLanguage(summary, language);
   const translateFn =
     translationEngine === TRANSLATION_ENGINES.OPUS
@@ -1094,7 +1150,16 @@ async function runSuggestQuestionsJob(payload) {
   try {
     let questions = [];
     try {
-      if (providerType === PROVIDERS.LOCAL) {
+      if (providerType === PROVIDERS.LLAMACPP) {
+        const { llamaHost, llamaApiKey } = await getSettings();
+        questions = await generateLocalSuggestions(
+          llamaHost,
+          model,
+          { title, url, summary, language },
+          LLAMACPP_PROVIDER,
+          llamaApiKey,
+        );
+      } else if (providerType === PROVIDERS.LOCAL) {
         questions = await generateLocalSuggestions(host, model, {
           title,
           url,
@@ -1547,6 +1612,46 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           await recordPopupSummaryStream(payload, streamId);
           startLocalHttpStream(streamId, payload);
           sendResponse({ streamId });
+          break;
+        }
+
+        case "llamacpp-stream": {
+          const streamId = nextStreamId("llamacpp");
+          const settings = await getSettings();
+          const trustedFinalize =
+            message.payload?.action === "summarize" || message.payload?.finalize
+              ? await buildTrustedFinalize(message.payload)
+              : null;
+          const payload = {
+            ...message.payload,
+            ...(trustedFinalize ? { finalize: trustedFinalize } : {}),
+            host: settings.llamaHost,
+            apiKey: settings.llamaApiKey,
+          };
+          await recordPopupSummaryStream(payload, streamId);
+          startLocalHttpStream(streamId, payload, LLAMACPP_PROVIDER);
+          sendResponse({ streamId });
+          break;
+        }
+
+        case "llamacpp-status": {
+          const { llamaHost, llamaApiKey } = await getSettings();
+          let validHost;
+          try {
+            validHost = validateLoopbackHost(
+              llamaHost,
+              LLAMACPP_PROVIDER.label,
+            );
+          } catch {
+            sendResponse({
+              connected: false,
+              models: [],
+              contextTokens: null,
+            });
+            break;
+          }
+          const response = await llamaCheckHealth(validHost, 3000, llamaApiKey);
+          sendResponse(response);
           break;
         }
 

--- a/apogee-extension/lib/constants.js
+++ b/apogee-extension/lib/constants.js
@@ -130,9 +130,17 @@ const DEFAULT_LOCAL_MODEL = "qwen3:8b";
 
 const isFirefox = process.env.TARGET_BROWSER === "firefox";
 
+// llama.cpp is offered on both builds: like Ollama it is a plain fetch to a
+// loopback server, with none of the WebGPU or offscreen-document dependency
+// that keeps WebLLM off Firefox.
 export const PROVIDERS = isFirefox
-  ? { TRANSFORMERS: "transformers", LOCAL: "local" }
-  : { WEBLLM: "webllm", TRANSFORMERS: "transformers", LOCAL: "local" };
+  ? { TRANSFORMERS: "transformers", LOCAL: "local", LLAMACPP: "llamacpp" }
+  : {
+      WEBLLM: "webllm",
+      TRANSFORMERS: "transformers",
+      LOCAL: "local",
+      LLAMACPP: "llamacpp",
+    };
 
 export const DEFAULT_PROVIDER = isFirefox
   ? PROVIDERS.TRANSFORMERS
@@ -140,12 +148,21 @@ export const DEFAULT_PROVIDER = isFirefox
 
 export const DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434";
 
+export const DEFAULT_LLAMACPP_HOST = "http://127.0.0.1:8080";
+
 export const DEFAULT_SETTINGS = {
   provider: DEFAULT_PROVIDER,
   webllmModel: DEFAULT_WEBLLM_MODEL,
   transformersModel: DEFAULT_TRANSFORMERS_MODEL,
   localModel: DEFAULT_LOCAL_MODEL,
   ollamaHost: DEFAULT_OLLAMA_HOST,
+  // llama-server loads one model at launch, so there is no list to pick from
+  // and no sensible default to ship: the name is filled in from the server
+  // once it answers. The API key stays empty unless the server was started
+  // with --api-key, which most are not.
+  llamaHost: DEFAULT_LLAMACPP_HOST,
+  llamaModel: "",
+  llamaApiKey: "",
   responseFormat: "bullets",
   customInstructions: "",
   summaryLanguage: DEFAULT_SUMMARY_LANGUAGE,

--- a/apogee-extension/lib/engines/providers.js
+++ b/apogee-extension/lib/engines/providers.js
@@ -2,6 +2,7 @@ import {
   PROVIDERS,
   DEFAULT_PROVIDER,
   DEFAULT_OLLAMA_HOST,
+  DEFAULT_LLAMACPP_HOST,
 } from "../constants.js";
 
 function sendToServiceWorker(message) {
@@ -118,6 +119,18 @@ async function startTransformersStream(action, payload) {
   const { streamId } = await sendToServiceWorker({
     target: "service-worker",
     action: "transformers-stream",
+    payload: { action, ...payload },
+  });
+  if (!streamId) {
+    throw new Error("No streamId returned from service worker");
+  }
+  return { streamId, stream: attachToStream(streamId) };
+}
+
+async function startLlamaCppStream(action, payload) {
+  const { streamId } = await sendToServiceWorker({
+    target: "service-worker",
+    action: "llamacpp-stream",
     payload: { action, ...payload },
   });
   if (!streamId) {
@@ -281,6 +294,70 @@ class DirectOllamaProvider {
   }
 }
 
+class DirectLlamaCppProvider {
+  constructor(model, host, apiKey) {
+    this.model = model;
+    this.host = (host || DEFAULT_LLAMACPP_HOST).replace(/\/+$/, "");
+    this.apiKey = apiKey || "";
+  }
+
+  summarize({
+    title,
+    url,
+    content,
+    mode,
+    type,
+    finalize,
+    language,
+    translationEngine,
+  }) {
+    return startLlamaCppStream("summarize", {
+      title,
+      url,
+      content,
+      mode,
+      type,
+      model: this.model,
+      host: this.host,
+      apiKey: this.apiKey,
+      finalize,
+      language,
+      translationEngine,
+    });
+  }
+
+  ask({ title, url, content, question, language, translationEngine }) {
+    return startLlamaCppStream("ask", {
+      title,
+      url,
+      content,
+      question,
+      model: this.model,
+      host: this.host,
+      apiKey: this.apiKey,
+      language,
+      translationEngine,
+    });
+  }
+
+  // `contextTokens` rides along because llama-server reports the window it is
+  // actually running, which no model name can imply. Null means it did not
+  // say, not that it is unlimited.
+  async checkReady() {
+    const response = await sendToServiceWorker({
+      target: "service-worker",
+      action: "llamacpp-status",
+      payload: { host: this.host, apiKey: this.apiKey },
+    });
+    return {
+      ready: response?.connected === true,
+      models: response?.models || [],
+      contextTokens: response?.contextTokens ?? null,
+      error: response?.error,
+    };
+  }
+}
+
 export function getProviderType(settings) {
   const provider = settings.provider;
   if (Object.values(PROVIDERS).includes(provider)) return provider;
@@ -289,6 +366,7 @@ export function getProviderType(settings) {
 
 export function getModelForSettings(settings) {
   if (settings.provider === PROVIDERS.LOCAL) return settings.localModel;
+  if (settings.provider === PROVIDERS.LLAMACPP) return settings.llamaModel;
   if (settings.provider === PROVIDERS.TRANSFORMERS) {
     return settings.transformersModel;
   }
@@ -299,6 +377,13 @@ export function getProvider(settings) {
   const type = getProviderType(settings);
   if (type === PROVIDERS.LOCAL) {
     return new DirectOllamaProvider(settings.localModel, settings.ollamaHost);
+  }
+  if (type === PROVIDERS.LLAMACPP) {
+    return new DirectLlamaCppProvider(
+      settings.llamaModel,
+      settings.llamaHost,
+      settings.llamaApiKey,
+    );
   }
   if (type === PROVIDERS.TRANSFORMERS) {
     return new TransformersProvider(settings.transformersModel);

--- a/apogee-extension/lib/engines/providers.js
+++ b/apogee-extension/lib/engines/providers.js
@@ -1,3 +1,4 @@
+import { UserFacingError } from "../util/userError.js";
 import {
   PROVIDERS,
   DEFAULT_PROVIDER,
@@ -26,6 +27,7 @@ export async function* attachToStream(streamId) {
   const queue = [];
   let resolvePromise = null;
   let error = null;
+  let errorUserFacing = false;
   let cancelled = false;
   let done = false;
 
@@ -39,6 +41,7 @@ export async function* attachToStream(streamId) {
       done = true;
     } else if (msg.type === "error") {
       error = msg.error || "Unknown error during streaming";
+      errorUserFacing = !!msg.userFacing;
       done = true;
     }
     if (resolvePromise) {
@@ -65,7 +68,7 @@ export async function* attachToStream(streamId) {
       } else if (cancelled) {
         throw new StreamCancelledError("Cancelled.");
       } else if (error) {
-        throw new Error(error);
+        throw errorUserFacing ? new UserFacingError(error) : new Error(error);
       } else if (done) {
         break;
       } else {

--- a/apogee-extension/lib/util/diagnostics.js
+++ b/apogee-extension/lib/util/diagnostics.js
@@ -16,7 +16,12 @@ function redact(key, value) {
     const entries = parsePrivateHosts(value);
     return entries.length ? `${entries.length} host(s)` : "unset";
   }
-  if (key === "ollamaHost") {
+  // An API key is a credential: a bug report should say whether one is set,
+  // never what it is.
+  if (key === "llamaApiKey") {
+    return value ? "set" : "unset";
+  }
+  if (key === "ollamaHost" || key === "llamaHost") {
     const host = String(value || "");
     try {
       const { hostname, port, protocol } = new URL(host);

--- a/apogee-extension/popup/popup.html
+++ b/apogee-extension/popup/popup.html
@@ -453,6 +453,14 @@
               <input type="radio" name="provider" value="local" />
               <span>Local Ollama</span>
             </label>
+
+            <label class="radio-option" id="llamacppProviderOption">
+              <input type="radio" name="provider" value="llamacpp" />
+              <span
+                >llama.cpp
+                <small class="provider-badge">llama-server</small></span
+              >
+            </label>
           </div>
 
           <div id="webllmModelsCard" class="settings-card">
@@ -497,6 +505,52 @@
 
             <div id="localModelList"></div>
             <div id="localModelStatus" class="clear-data-status"></div>
+          </div>
+
+          <div id="llamaSettingsCard" class="settings-card hidden">
+            <div class="card-title">
+              <span class="ico" data-ico="server" aria-hidden="true"></span>
+              <span>llama.cpp</span>
+            </div>
+
+            <label class="settings-field">
+              <span>Server URL</span>
+              <input
+                id="llamaHostInput"
+                type="url"
+                placeholder="http://127.0.0.1:8080"
+              />
+            </label>
+
+            <label class="settings-field">
+              <span
+                >API key <small>(only if started with --api-key)</small></span
+              >
+              <input
+                id="llamaApiKeyInput"
+                type="password"
+                autocomplete="off"
+                placeholder="Leave empty for most servers"
+              />
+            </label>
+          </div>
+
+          <div id="llamaModelsCard" class="settings-card hidden">
+            <div class="card-title">
+              <span class="ico" data-ico="robot" aria-hidden="true"></span>
+              <span>Loaded Model</span>
+            </div>
+
+            <label class="settings-field">
+              <span>Model name</span>
+              <input
+                id="llamaModelInput"
+                type="text"
+                autocomplete="off"
+                placeholder="Detected from the server"
+              />
+            </label>
+            <div id="llamaModelStatus" class="clear-data-status"></div>
           </div>
 
           <div class="settings-card">

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -20,6 +20,7 @@ import {
   TRANSFORMERS_MODELS,
   LOCAL_MODELS,
   DEFAULT_OLLAMA_HOST,
+  DEFAULT_LLAMACPP_HOST,
   SUMMARY_LANGUAGES,
   CUSTOM_INSTRUCTIONS_MAX_CHARS,
   PRIVATE_HOSTS_MAX_CHARS,
@@ -185,6 +186,12 @@ const transformersModelsCard = document.getElementById(
 );
 const localSettingsCard = document.getElementById("localSettingsCard");
 const localModelsCard = document.getElementById("localModelsCard");
+const llamaSettingsCard = document.getElementById("llamaSettingsCard");
+const llamaModelsCard = document.getElementById("llamaModelsCard");
+const llamaHostInput = document.getElementById("llamaHostInput");
+const llamaApiKeyInput = document.getElementById("llamaApiKeyInput");
+const llamaModelInput = document.getElementById("llamaModelInput");
+const llamaModelStatus = document.getElementById("llamaModelStatus");
 const webllmModelList = document.getElementById("webllmModelList");
 const transformersModelList = document.getElementById("transformersModelList");
 const localModelList = document.getElementById("localModelList");
@@ -460,16 +467,23 @@ async function applySettingsToUI(settings) {
   const isWebllm = provider === PROVIDERS.WEBLLM;
   const isTransformers = provider === PROVIDERS.TRANSFORMERS;
   const isLocal = provider === PROVIDERS.LOCAL;
+  const isLlamaCpp = provider === PROVIDERS.LLAMACPP;
   webllmModelsCard.classList.toggle("hidden", !isWebllm);
   transformersModelsCard?.classList.toggle("hidden", !isTransformers);
   localSettingsCard.classList.toggle("hidden", !isLocal);
   localModelsCard.classList.toggle("hidden", !isLocal);
+  llamaSettingsCard?.classList.toggle("hidden", !isLlamaCpp);
+  llamaModelsCard?.classList.toggle("hidden", !isLlamaCpp);
 
   buildWebllmModelUI(settings.webllmModel);
   buildTransformersModelUI(settings.transformersModel);
 
   if (backendUrlInput) backendUrlInput.value = settings.ollamaHost;
   buildLocalModelUI(settings.localModel);
+
+  if (llamaHostInput) llamaHostInput.value = settings.llamaHost;
+  if (llamaApiKeyInput) llamaApiKeyInput.value = settings.llamaApiKey || "";
+  if (llamaModelInput) llamaModelInput.value = settings.llamaModel || "";
 
   const fmtRadio = document.querySelector(
     `input[name="format"][value="${settings.responseFormat}"]`,
@@ -1683,6 +1697,60 @@ async function checkConnection() {
   return await provider.checkReady();
 }
 
+/**
+ * Reflect what llama-server reported back into the model field.
+ *
+ * llama-server loads one model at launch, so unlike Ollama there is no list to
+ * choose from -- the field is filled in from the server instead. It stays
+ * editable for the cases detection cannot cover: a proxy such as llama-swap
+ * routing by model name, or a build whose /v1/models says something unhelpful.
+ *
+ * Auto-fill only touches an empty field, which is what keeps a name the user
+ * typed, and a name detected earlier, from being overwritten on the next
+ * health check. Clearing the field asks for detection again.
+ */
+function updateLlamaModelUI(settings, status) {
+  if (settings.provider !== PROVIDERS.LLAMACPP) return;
+  if (!llamaModelInput) return;
+
+  const detected = Array.isArray(status?.models) ? status.models : [];
+
+  if (detected.length > 0 && !llamaModelInput.value.trim()) {
+    llamaModelInput.value = detected[0];
+    saveSettings({ llamaModel: detected[0] }).catch((err) =>
+      console.error("Saving the detected llama.cpp model failed:", err),
+    );
+  }
+
+  if (!llamaModelStatus) return;
+
+  if (!status?.ready) {
+    renderStatusError(
+      llamaModelStatus,
+      "Not connected. Start llama-server and check the URL above.",
+    );
+    return;
+  }
+
+  llamaModelStatus.removeAttribute("role");
+  if (detected.length === 0) {
+    // /health answered but the model lookup did not, which is what a wrong
+    // API key looks like: reachable, but nothing readable behind it.
+    llamaModelStatus.textContent = settings.llamaApiKey
+      ? "Connected, but the model could not be read. Check the API key."
+      : "Connected, but the server did not report a model name.";
+    return;
+  }
+
+  const context = status.contextTokens
+    ? `${status.contextTokens.toLocaleString()} token context`
+    : "context window not reported";
+  llamaModelStatus.textContent =
+    detected.length > 1
+      ? `${detected.length} models available, ${context}.`
+      : `Detected from the server, ${context}.`;
+}
+
 function updateLocalModelList(settings, status) {
   if (settings.provider !== PROVIDERS.LOCAL) return;
 
@@ -1773,6 +1841,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       .then((status) => {
         updateConnectionUI(status?.ready === true);
         updateLocalModelList(settings, status);
+        updateLlamaModelUI(settings, status);
       })
       .catch((err) => console.error(err));
 
@@ -2202,6 +2271,7 @@ providerRadios.forEach((radio) => {
     const status = await checkConnection();
     updateConnectionUI(status?.ready === true);
     updateLocalModelList(settings, status);
+    updateLlamaModelUI(settings, status);
   });
 });
 
@@ -2449,6 +2519,35 @@ backendUrlInput?.addEventListener("change", async () => {
   const status = await checkConnection();
   updateConnectionUI(status?.ready === true);
   updateLocalModelList(settings, status);
+  updateLlamaModelUI(settings, status);
+});
+
+async function refreshLlamaConnection() {
+  const settings = await getSettings();
+  const status = await checkConnection();
+  updateConnectionUI(status?.ready === true);
+  updateLlamaModelUI(settings, status);
+}
+
+llamaHostInput?.addEventListener("change", async () => {
+  let val = (llamaHostInput.value || DEFAULT_LLAMACPP_HOST).trim();
+  if (val && !/^https?:\/\//i.test(val)) {
+    val = `http://${val}`;
+  }
+  val = val.replace(/\/+$/, "");
+  llamaHostInput.value = val;
+  await saveSettings({ llamaHost: val });
+  await refreshLlamaConnection();
+});
+
+llamaApiKeyInput?.addEventListener("change", async () => {
+  await saveSettings({ llamaApiKey: llamaApiKeyInput.value.trim() });
+  // The key gates the model lookup, so a corrected one should re-detect.
+  await refreshLlamaConnection();
+});
+
+llamaModelInput?.addEventListener("change", async () => {
+  await saveSettings({ llamaModel: llamaModelInput.value.trim() });
 });
 
 promptsCloseBtn?.addEventListener("click", () => {

--- a/apogee-extension/tests/engines/attachToStream.test.js
+++ b/apogee-extension/tests/engines/attachToStream.test.js
@@ -5,6 +5,7 @@ import {
   attachToStream,
   StreamCancelledError,
 } from "../../lib/engines/providers.js";
+import { toUserMessage } from "../../lib/util/userError.js";
 
 function createFakePort() {
   const listeners = { message: [], disconnect: [] };
@@ -80,4 +81,47 @@ test("attachToStream errors (instead of silently truncating) when the port disco
   port._emitDisconnect();
 
   await assert.rejects(run, /Connection to the model was lost/);
+});
+
+// A message written for the user only survives the port if the marker travels
+// with it. Without this, attachToStream rebuilt a plain Error, toUserMessage
+// fell through to its pattern table, and "Could not connect to llama.cpp..."
+// was rewritten as "Could not connect to Ollama..." because the table matches
+// on "could not connect".
+test("attachToStream keeps an error that was written for the user intact", async () => {
+  const port = createFakePort();
+  globalThis.chrome = { runtime: { connect: () => port } };
+
+  const run = collect(attachToStream("stream-user-facing"));
+  await new Promise((r) => setTimeout(r, 0));
+
+  const written =
+    "Could not connect to llama.cpp at http://127.0.0.1:8080. " +
+    "Is llama-server running and listening on that address?";
+  port._emitMessage({ type: "error", error: written, userFacing: true });
+
+  await assert.rejects(run, (err) => {
+    assert.equal(err.isUserFacing, true, "marker must survive the port");
+    assert.equal(
+      toUserMessage(err),
+      written,
+      "a user-facing message must not be run through the fallback table",
+    );
+    return true;
+  });
+});
+
+test("attachToStream still lets an unmarked error be mapped to a fallback", async () => {
+  const port = createFakePort();
+  globalThis.chrome = { runtime: { connect: () => port } };
+
+  const run = collect(attachToStream("stream-raw"));
+  await new Promise((r) => setTimeout(r, 0));
+
+  port._emitMessage({ type: "error", error: "TypeError: fetch failed" });
+
+  await assert.rejects(run, (err) => {
+    assert.notEqual(err.isUserFacing, true);
+    return true;
+  });
 });

--- a/apogee-extension/tests/engines/providers.test.js
+++ b/apogee-extension/tests/engines/providers.test.js
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import {
+  getProvider,
+  getProviderType,
+  getModelForSettings,
+} from "../../lib/engines/providers.js";
+import {
+  PROVIDERS,
+  DEFAULT_PROVIDER,
+  DEFAULT_SETTINGS,
+  DEFAULT_LLAMACPP_HOST,
+} from "../../lib/constants.js";
+
+const settings = (overrides) => ({ ...DEFAULT_SETTINGS, ...overrides });
+
+test("every provider in the registry resolves to its own implementation", () => {
+  const seen = new Map();
+  for (const type of Object.values(PROVIDERS)) {
+    const provider = getProvider(settings({ provider: type }));
+    seen.set(type, provider.constructor.name);
+  }
+  // Each provider must get its own class; two mapping to the same one would
+  // mean a missing branch in getProvider silently falling through.
+  assert.equal(
+    new Set(seen.values()).size,
+    seen.size,
+    `providers collapsed onto the same class: ${JSON.stringify([...seen])}`,
+  );
+  assert.equal(seen.get(PROVIDERS.LLAMACPP), "DirectLlamaCppProvider");
+});
+
+test("getProviderType passes a known provider through and rejects anything else", () => {
+  assert.equal(
+    getProviderType(settings({ provider: PROVIDERS.LLAMACPP })),
+    PROVIDERS.LLAMACPP,
+  );
+  assert.equal(
+    getProviderType(settings({ provider: "nonsense" })),
+    DEFAULT_PROVIDER,
+  );
+  assert.equal(
+    getProviderType(settings({ provider: undefined })),
+    DEFAULT_PROVIDER,
+  );
+});
+
+// Each provider reads its model from its own settings key. Reading the wrong
+// one would send an empty or foreign model name to the server, and would also
+// poison the summary cache key, which is built from this value.
+test("getModelForSettings reads each provider's own model key", () => {
+  const configured = settings({
+    webllmModel: "webllm-one",
+    transformersModel: "transformers-one",
+    localModel: "ollama-one",
+    llamaModel: "llamacpp-one",
+  });
+  assert.equal(
+    getModelForSettings({ ...configured, provider: PROVIDERS.LLAMACPP }),
+    "llamacpp-one",
+  );
+  assert.equal(
+    getModelForSettings({ ...configured, provider: PROVIDERS.LOCAL }),
+    "ollama-one",
+  );
+  assert.equal(
+    getModelForSettings({ ...configured, provider: PROVIDERS.TRANSFORMERS }),
+    "transformers-one",
+  );
+});
+
+test("the llama.cpp provider carries the configured host, model and key", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LLAMACPP,
+      llamaHost: "http://localhost:9999",
+      llamaModel: "some-model.gguf",
+      llamaApiKey: "test-api-key",
+    }),
+  );
+  assert.equal(provider.host, "http://localhost:9999");
+  assert.equal(provider.model, "some-model.gguf");
+  assert.equal(provider.apiKey, "test-api-key");
+});
+
+test("the llama.cpp provider falls back to the default host and an absent key", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LLAMACPP,
+      llamaHost: "",
+      llamaApiKey: undefined,
+    }),
+  );
+  assert.equal(provider.host, DEFAULT_LLAMACPP_HOST);
+  assert.equal(provider.apiKey, "");
+});
+
+// A trailing slash would produce "http://host//v1/chat/completions".
+test("the llama.cpp provider strips trailing slashes from the host", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LLAMACPP,
+      llamaHost: "http://127.0.0.1:8080///",
+    }),
+  );
+  assert.equal(provider.host, "http://127.0.0.1:8080");
+});
+
+test("llama.cpp settings defaults are present and inert", () => {
+  assert.equal(DEFAULT_SETTINGS.llamaHost, DEFAULT_LLAMACPP_HOST);
+  // Empty until the server is asked what it is serving.
+  assert.equal(DEFAULT_SETTINGS.llamaModel, "");
+  assert.equal(DEFAULT_SETTINGS.llamaApiKey, "");
+  // Adding a provider must not change which one users get by default.
+  assert.notEqual(DEFAULT_PROVIDER, PROVIDERS.LLAMACPP);
+});
+
+test("adding llama.cpp left the Ollama provider untouched", () => {
+  const provider = getProvider(
+    settings({
+      provider: PROVIDERS.LOCAL,
+      localModel: "qwen3:8b",
+      ollamaHost: "http://127.0.0.1:11434",
+    }),
+  );
+  assert.equal(provider.constructor.name, "DirectOllamaProvider");
+  assert.equal(provider.host, "http://127.0.0.1:11434");
+  assert.equal(provider.model, "qwen3:8b");
+});

--- a/apogee-extension/tests/popup/llamaCppSettings.test.js
+++ b/apogee-extension/tests/popup/llamaCppSettings.test.js
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { parseHTML } from "linkedom";
+
+import { PROVIDERS, DEFAULT_SETTINGS } from "../../lib/constants.js";
+import { formatDiagnosticSettings } from "../../lib/util/diagnostics.js";
+
+const popupHtml = readFileSync(
+  new URL("../../popup/popup.html", import.meta.url),
+  "utf8",
+);
+const popupJs = readFileSync(
+  new URL("../../popup/popup.js", import.meta.url),
+  "utf8",
+);
+
+test("popup.html offers llama.cpp in the provider list", () => {
+  const { document } = parseHTML(popupHtml);
+  const radio = document.querySelector(
+    'input[name="provider"][value="llamacpp"]',
+  );
+  assert.ok(radio, "a provider radio with value llamacpp must exist");
+  assert.equal(
+    radio.getAttribute("value"),
+    PROVIDERS.LLAMACPP,
+    "the radio value must match the PROVIDERS entry the settings are keyed by",
+  );
+});
+
+test("popup.html carries the llama.cpp settings fields", () => {
+  const { document } = parseHTML(popupHtml);
+  for (const id of [
+    "llamaSettingsCard",
+    "llamaModelsCard",
+    "llamaHostInput",
+    "llamaApiKeyInput",
+    "llamaModelInput",
+    "llamaModelStatus",
+  ]) {
+    assert.ok(document.getElementById(id), `#${id} must exist in popup.html`);
+  }
+});
+
+// The model is typed or auto-filled, not chosen: llama-server loads exactly
+// one model at launch, so there is no list to render.
+test("the llama.cpp model control is a text field, not a radio list", () => {
+  const { document } = parseHTML(popupHtml);
+  const input = document.getElementById("llamaModelInput");
+  assert.equal(input.tagName.toLowerCase(), "input");
+  assert.equal(input.getAttribute("type"), "text");
+});
+
+test("the API key field is masked and kept out of autofill", () => {
+  const { document } = parseHTML(popupHtml);
+  const input = document.getElementById("llamaApiKeyInput");
+  assert.equal(
+    input.getAttribute("type"),
+    "password",
+    "an API key must not be rendered in clear text",
+  );
+  assert.equal(input.getAttribute("autocomplete"), "off");
+});
+
+test("the llama.cpp cards start hidden, like the other provider cards", () => {
+  const { document } = parseHTML(popupHtml);
+  for (const id of ["llamaSettingsCard", "llamaModelsCard"]) {
+    assert.ok(
+      document.getElementById(id).className.includes("hidden"),
+      `#${id} must be hidden until llama.cpp is the selected provider`,
+    );
+  }
+});
+
+test("the llama.cpp cards reuse existing card and field classes", () => {
+  const { document } = parseHTML(popupHtml);
+  assert.ok(
+    document
+      .getElementById("llamaSettingsCard")
+      .className.includes("settings-card"),
+  );
+  assert.ok(
+    document.getElementById("llamaHostInput").closest(".settings-field"),
+    "the host input must sit in a .settings-field like the Ollama one",
+  );
+});
+
+test("popup.js toggles the llama.cpp cards on the provider", () => {
+  assert.match(popupJs, /PROVIDERS\.LLAMACPP/);
+  assert.match(popupJs, /llamaSettingsCard\?\.classList\.toggle\("hidden"/);
+  assert.match(popupJs, /llamaModelsCard\?\.classList\.toggle\("hidden"/);
+});
+
+// Auto-fill must only touch an empty field, so a name the user typed and a
+// name detected earlier both survive the next health check.
+test("popup.js only auto-fills the model field when it is empty", () => {
+  const guard =
+    /if \(detected\.length > 0 && !llamaModelInput\.value\.trim\(\)\)/;
+  assert.match(popupJs, guard, "auto-fill must be guarded on an empty field");
+});
+
+test("the settings keys the UI writes are the ones that ship as defaults", () => {
+  for (const key of ["llamaHost", "llamaModel", "llamaApiKey"]) {
+    assert.ok(
+      key in DEFAULT_SETTINGS,
+      `${key} must exist in DEFAULT_SETTINGS or diagnostics will not report it`,
+    );
+    assert.match(popupJs, new RegExp(`saveSettings\\(\\{ ${key}`));
+  }
+});
+
+test("a bug report reports the API key's presence, never its value", () => {
+  const report = formatDiagnosticSettings({
+    ...DEFAULT_SETTINGS,
+    llamaApiKey: "a-real-looking-credential",
+    llamaHost: "http://192.168.1.50:8080",
+  });
+  assert.ok(
+    !report.includes("a-real-looking-credential"),
+    "the API key must never appear in a copied diagnostics report",
+  );
+  assert.match(report, /llamaApiKey: set/);
+  // A host outside loopback names a machine on the user's network.
+  assert.ok(!report.includes("192.168.1.50"));
+  assert.match(report, /llamaHost: custom host, port 8080/);
+});
+
+test("an unset key and a loopback host are reported plainly", () => {
+  const report = formatDiagnosticSettings(DEFAULT_SETTINGS);
+  assert.match(report, /llamaApiKey: unset/);
+  assert.match(report, /llamaHost: http:\/\/127\.0\.0\.1:8080/);
+});


### PR DESCRIPTION
## Summary

### In the previous PRs

**PR 1 — llama.cpp client (merged)**
`lib/engines/llamaCppClient.js`: `chatStream` (SSE against `/v1/chat/completions`) and `checkHealth` (`/health` for reachability, `/v1/models` for the model name, `/props` for the context window). Handles two wire-format quirks found against a live server — the opening chunk sends `content: null`, and `[DONE]` arrives with no trailing blank line.

**PR 2 — loopback streaming refactor (merged)**
`startOllamaStream` → `startLocalHttpStream(streamId, payload, client)`, so a second loopback provider needs no cloned dispatch path. Behaviour-preserving; regression-tested against a real Ollama.

**PR 3 — dynamic context window (merged)**
`getMaxChunkChars(model, contextTokensOverride)`. llama-server takes its window from its own `-c` flag, so the model name can't imply it.

**PR 4 — provider registration (open)**
`PROVIDERS.LLAMACPP`, the `llamaHost` / `llamaModel` / `llamaApiKey` settings keys, and `DirectLlamaCppProvider`.

**PR 5 — service worker routing (open)**
`llamacpp-stream` / `llamacpp-status` handlers, the dispatch branches, and the context-window → chunk-size wiring. Also carries a fix that browser testing surfaced (below).

## This PR

Adds the provider radio, a card for server URL and optional API key, and a card for the loaded model — all from the existing `settings-card` / `radio-option` / `settings-field` classes, so no new CSS.

The model control is a text field, not a radio list. llama-server loads one model at launch, so there's nothing to choose between: the field fills itself from `/v1/models` once the server answers. It stays editable for what detection can't cover — a proxy such as llama-swap routing by model name, or a build whose `/v1/models` reports something unhelpful.

Auto-fill only writes into an empty field. That single rule keeps both a name the user typed and a name detected earlier from being overwritten on the next health check, with no "was this edited" flag to keep in sync. Clearing the field asks for detection again.

The status line separates states that otherwise look identical: disconnected; connected with a model and its context window; connected with several models behind a proxy; and connected but unable to read one — which is what a wrong API key looks like, since `/health` is public while `/v1/models` is not.

Diagnostics: `llamaApiKey` reports as set / unset, never its value, and `llamaHost` goes through the same loopback-or-shape redaction `ollamaHost` already uses. A copied bug report can't leak a credential or name a machine on someone's network.

## Verified in a browser

Loaded unpacked in Chrome against llama-server b10603 started with `-c 4096`:

- Provider selection shows/hides the right cards; status dot connects
- Model field auto-fills `Qwen/Qwen2.5-0.5B-Instruct-GGUF:Q4_K_M`, status reads "Detected from the server, 4,096 token context" — the name implies 32k, so this is detection beating the model-name guess, which is what PR 3 exists for
- Summarize and Ask both stream real output; cancel stops cleanly
- A typed model name survives a reload; clearing the field re-detects

Browser testing found a real bug, now fixed in PR 5: a llama.cpp connection failure was surfacing as "Could not connect to Ollama." The `UserFacingError` marker doesn't survive `chrome.runtime` port serialisation, so `attachToStream` rebuilt a plain `Error` and `toUserMessage` matched it against `/ollama|could not connect/i`. Pre-existing — Ollama's errors were flattened identically, it just happened to look right. Worth noting that fix slightly improves error fidelity for all providers, not only this one.

Part of #91

## Test plan

<!-- How did you verify this? Check the boxes you actually ran. -->

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [x] Manually exercised the change in a loaded browser extension

## Privacy impact

<!-- Does this add, remove, or change any outbound network request or permission? -->

- [x] No new outbound network calls
- [ ] Adds/changes a network call (described above, docs updated)

<!-- Permissions and network behaviour are described in four places that must
     agree: apogee-extension/manifest.json, README.md (Privacy & Permissions),
     PRIVACY.md, and store-listing.md (permission justifications). A claim in
     one and not the others is what store reviewers catch. -->

- [x] Permissions unchanged, or all four of manifest / README / PRIVACY /
      store-listing updated together
