### PR TITLE
feat: add plain-text summary export

### DIFF
--- a/apogee-extension/lib/util/exportFormat.js
+++ b/apogee-extension/lib/util/exportFormat.js
@@ -29,3 +29,16 @@ export function formatSummaryAsMarkdown({
   parts.push(summary || "");
   return parts.join("\n\n").trim() + "\n";
 }
+export function formatSummaryAsPlainText({ title, url, summary }) {
+  const plainSummary = (summary || "")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/\*\*(.*?)\*\*/g, "$1")
+    .replace(/__(.*?)__/g, "$1")
+    .replace(/[*_~`]/g, "");
+
+  const parts = [title || "Summary"];
+  if (url) parts.push(`Source: ${url}`);
+  parts.push(plainSummary);
+
+  return parts.join("\n\n").trim() + "\n";
+}

--- a/apogee-extension/popup/popup.html
+++ b/apogee-extension/popup/popup.html
@@ -277,6 +277,15 @@
                 </button>
 
                 <button
+                  id="copyPlainTextBtn"
+                  class="copy-btn hidden"
+                  aria-label="Copy as plain text"
+                  title="Copy as plain text"
+                >
+                  <span class="ico" data-ico="copy" aria-hidden="true"></span>
+                </button>
+
+                <button
                   id="copySummaryBtn"
                   class="copy-btn hidden"
                   aria-label="Copy summary"

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -27,7 +27,10 @@ import {
 } from "../lib/constants.js";
 import { getSettings } from "../lib/storage/settings.js";
 import { validateOllamaHost } from "../lib/util/ollamaHost.js";
-import { formatSummaryAsMarkdown } from "../lib/util/exportFormat.js";
+import {
+  formatSummaryAsMarkdown,
+  formatSummaryAsPlainText,
+} from "../lib/util/exportFormat.js";
 import {
   formatDiagnosticSettings,
   formatDiagnosticsMarkdown,
@@ -130,6 +133,7 @@ const resummarizeHintBtn = document.getElementById("resummarizeHintBtn");
 const timeSavedBadge = document.getElementById("timeSavedBadge");
 const copySummaryBtn = document.getElementById("copySummaryBtn");
 const copyMarkdownBtn = document.getElementById("copyMarkdownBtn");
+const copyPlainTextBtn = document.getElementById("copyPlainTextBtn");
 const copyAnswerBtn = document.getElementById("copyAnswerBtn");
 const cancelAskBtn = document.getElementById("cancelAskBtn");
 const pastSummariesSection = document.getElementById("pastSummariesSection");
@@ -1145,6 +1149,7 @@ function showTimeSavedFromInputs(inputs, summaryText) {
 function setSummaryCopyButtonsVisible(hasText) {
   copySummaryBtn.classList.toggle("hidden", !hasText);
   copyMarkdownBtn?.classList.toggle("hidden", !hasText);
+  copyPlainTextBtn?.classList.toggle("hidden", !hasText);
   resummarizeBtn?.classList.toggle("hidden", !hasText);
 }
 
@@ -1180,8 +1185,26 @@ copyMarkdownBtn?.addEventListener("click", async () => {
     url,
     summary: currentSummaryText,
   });
+
   copyToClipboard(markdown, copyMarkdownBtn);
 });
+
+copyPlainTextBtn?.addEventListener("click", async () => {
+  const [tab] = await chrome.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  const title = currentPageData?.title || tab?.title || "";
+  const url = currentPageData?.url || tab?.url || "";
+  const plainText = formatSummaryAsPlainText({
+    title,
+    url,
+    summary: currentSummaryText,
+  });
+
+  copyToClipboard(plainText, copyPlainTextBtn);
+});
+
 copyAnswerBtn?.addEventListener("click", () =>
   copyToClipboard(currentAnswerText, copyAnswerBtn),
 );

--- a/apogee-extension/tests/util/exportFormat.test.js
+++ b/apogee-extension/tests/util/exportFormat.test.js
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert";
-import { formatSummaryAsMarkdown } from "../../lib/util/exportFormat.js";
+import {
+  formatSummaryAsMarkdown,
+  formatSummaryAsPlainText,
+} from "../../lib/util/exportFormat.js";
 
 test("formatSummaryAsMarkdown includes title, source, and summary", () => {
   const result = formatSummaryAsMarkdown({
@@ -62,5 +65,17 @@ test("formatSummaryAsMarkdown includes YAML frontmatter when includeFrontmatter 
     result.includes(
       "# Obsidian Note\n\nSource: https://example.com/obsidian\n\n- Important point\n",
     ),
+  );
+});
+test("formatSummaryAsPlainText removes Markdown formatting", () => {
+  const result = formatSummaryAsPlainText({
+    title: "Example Article",
+    url: "https://example.com/article",
+    summary: "## Key points\n\n- **First point**\n- _Second point_",
+  });
+
+  assert.strictEqual(
+    result,
+    "Example Article\n\nSource: https://example.com/article\n\nKey points\n\n- First point\n- Second point\n",
   );
 });


### PR DESCRIPTION
## Summary

Adds support for copying generated summaries in a plain-text format for use in email, notes, and other applications where Markdown formatting is not supported.

## Changes

* Added `formatSummaryAsPlainText`
* Removed Markdown formatting symbols from exported summaries
* Added a “Copy as plain text” button to the popup
* Added unit test coverage for plain-text formatting

## Testing

* `npm run format:check` ✅
* `npm run lint` ✅
* Formatter unit tests ✅
* Chrome build ✅
* Firefox build ✅

The full test suite has two existing Windows path-related failures in `tests/manifest.test.js`; the relevant formatter tests pass.

Closes #144
