### PR TITLE
feat(popup): show tokens/sec while a summary or answer streams

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -12,6 +12,12 @@ import {
   DEFAULT_CONTEXT_TOKENS as LLAMACPP_DEFAULT_CONTEXT_TOKENS,
 } from "../lib/engines/llamaCppClient.js";
 import { getMaxChunkChars } from "../lib/engines/modelLimits.js";
+import {
+  tokensForChunk,
+  isWarmedUp,
+  tokensPerSecond,
+  finalTokensPerSecond,
+} from "../lib/util/throughput.js";
 import { chunkBySections } from "../lib/summarize/sections.js";
 import { errorHelpUrl } from "../lib/util/errorHelp.js";
 import { toUserMessage } from "../lib/util/userError.js";
@@ -416,13 +422,29 @@ function createBufferedStream(streamId, { finalize, model, title, url }) {
     cancelled: false,
     subscribers: new Set(),
     controller: new AbortController(),
+    tokenCount: 0,
+    firstTokenTime: null,
+    tokensPerSec: null,
   };
   activeStreams.set(streamId, stream);
   startKeepAlive();
 
   const finish = (msg) => {
     if (stream.cancelled) return;
-    if (msg.type === "done") stream.done = true;
+    if (msg.type === "done") {
+      stream.done = true;
+      const elapsedMs =
+        stream.firstTokenTime != null
+          ? performance.now() - stream.firstTokenTime
+          : 0;
+      stream.tokensPerSec =
+        finalTokensPerSecond({
+          serverStats: msg.serverStats ?? null,
+          tokenCount: stream.tokenCount,
+          elapsedMs,
+        }) || null;
+      msg = { ...msg, tokensPerSec: stream.tokensPerSec };
+    }
     if (msg.type === "error") {
       stream.error = msg.error;
       stream.errorUserFacing = !!msg.userFacing;
@@ -438,7 +460,17 @@ function createBufferedStream(streamId, { finalize, model, title, url }) {
   const emitChunk = (text) => {
     if (!text || stream.cancelled) return;
     stream.text += text;
+    if (stream.firstTokenTime == null)
+      stream.firstTokenTime = performance.now();
+    stream.tokenCount += tokensForChunk(text);
     broadcastToStream(stream, { type: "chunk", text });
+    const elapsedMs = performance.now() - stream.firstTokenTime;
+    if (isWarmedUp(stream.tokenCount, elapsedMs)) {
+      broadcastToStream(stream, {
+        type: "stats",
+        tokensPerSec: tokensPerSecond(stream.tokenCount, elapsedMs),
+      });
+    }
   };
 
   return { stream, finish, emitChunk };
@@ -484,10 +516,21 @@ async function startLocalHttpStream(
 
   const { customInstructions } = await getSettings();
 
+  // Populated once the final chunk carries the backend's own token count and
+  // duration (Ollama's eval_count/eval_duration, llama.cpp's timings). It is
+  // more accurate than our own count since it excludes network transit.
+  let serverStats = null;
+
   // Ollama's client ignores the extra option; llama.cpp's uses it when the
   // server was started with --api-key.
   const chatStreamFn = (h, m, p, opts) =>
-    client.chatStream(h, m, p, { ...opts, apiKey });
+    client.chatStream(h, m, p, {
+      ...opts,
+      apiKey,
+      onFinalStats: (s) => {
+        serverStats = s;
+      },
+    });
 
   // Only a provider that can report its own window gets an explicit chunk
   // size; everyone else keeps the model-name inference in getMaxChunkChars.
@@ -577,7 +620,7 @@ async function startLocalHttpStream(
     for await (const token of generator) {
       emitChunk(token);
     }
-    finish({ type: "done" });
+    finish({ type: "done", serverStats });
   } catch (err) {
     finish({
       type: "error",
@@ -1493,8 +1536,21 @@ if (typeof chrome !== "undefined" && chrome.runtime?.onConnect?.addListener) {
       } catch {}
     } else if (stream.done) {
       try {
-        popupPort.postMessage({ type: "done" });
+        popupPort.postMessage({
+          type: "done",
+          tokensPerSec: stream.tokensPerSec,
+        });
       } catch {}
+    } else if (stream.firstTokenTime != null) {
+      const elapsedMs = performance.now() - stream.firstTokenTime;
+      if (isWarmedUp(stream.tokenCount, elapsedMs)) {
+        try {
+          popupPort.postMessage({
+            type: "stats",
+            tokensPerSec: tokensPerSecond(stream.tokenCount, elapsedMs),
+          });
+        } catch {}
+      }
     }
 
     popupPort.onDisconnect.addListener(() => {

--- a/apogee-extension/lib/engines/llamaCppClient.js
+++ b/apogee-extension/lib/engines/llamaCppClient.js
@@ -81,7 +81,7 @@ function dataPayloadsOf(block) {
   return payloads;
 }
 
-function readEventBlock(block, model) {
+function readEventBlock(block, model, onFinalStats) {
   const tokens = [];
   for (const payload of dataPayloadsOf(block)) {
     if (payload === SSE_DONE) return { tokens, done: true };
@@ -112,6 +112,16 @@ function readEventBlock(block, model) {
     // type skips both, while still passing a single-space token through, which
     // a truthiness check would drop.
     if (typeof content === "string" && content !== "") tokens.push(content);
+
+    // llama.cpp's own `timings` (a native extension, not part of the OpenAI
+    // schema) rides on the final chunk when the request asks for usage. It is
+    // more accurate than our own count: it excludes network transit.
+    if (parsed?.timings?.predicted_n != null) {
+      onFinalStats?.({
+        tokens: parsed.timings.predicted_n,
+        durationMs: parsed.timings.predicted_ms,
+      });
+    }
   }
   return { tokens, done: false };
 }
@@ -120,7 +130,7 @@ export async function* chatStream(
   host,
   model,
   prompt,
-  { signal, system, apiKey } = {},
+  { signal, system, apiKey, onFinalStats } = {},
 ) {
   const messages = system
     ? [
@@ -139,7 +149,12 @@ export async function* chatStream(
         "Content-Type": "application/json",
         ...authHeaders(apiKey),
       },
-      body: JSON.stringify({ model, messages, stream: true }),
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: true,
+        stream_options: { include_usage: true },
+      }),
       signal,
     });
   } catch (err) {
@@ -174,7 +189,11 @@ export async function* chatStream(
       while ((boundary = buffer.indexOf("\n\n")) !== -1) {
         const block = buffer.slice(0, boundary);
         buffer = buffer.slice(boundary + 2);
-        const { tokens, done: finished } = readEventBlock(block, model);
+        const { tokens, done: finished } = readEventBlock(
+          block,
+          model,
+          onFinalStats,
+        );
         yield* tokens;
         if (finished) return;
       }
@@ -186,7 +205,7 @@ export async function* chatStream(
     // for the same reason.
     const trailing = buffer.trim();
     if (trailing) {
-      const { tokens } = readEventBlock(trailing, model);
+      const { tokens } = readEventBlock(trailing, model, onFinalStats);
       yield* tokens;
     }
   } catch (err) {

--- a/apogee-extension/lib/engines/ollamaClient.js
+++ b/apogee-extension/lib/engines/ollamaClient.js
@@ -13,7 +13,7 @@ export async function* chatStream(
   host,
   model,
   prompt,
-  { signal, keepAlive = "5m", system } = {},
+  { signal, keepAlive = "5m", system, onFinalStats } = {},
 ) {
   const messages = system
     ? [
@@ -85,6 +85,12 @@ export async function* chatStream(
         }
         const text = parsed.message?.content;
         if (text) yield text;
+        if (parsed.eval_count != null && parsed.eval_duration != null) {
+          onFinalStats?.({
+            tokens: parsed.eval_count,
+            durationMs: parsed.eval_duration / 1e6,
+          });
+        }
       }
     }
     const trailing = buffer.trim();
@@ -92,6 +98,12 @@ export async function* chatStream(
       const parsed = JSON.parse(trailing);
       const text = parsed.message?.content;
       if (text) yield text;
+      if (parsed.eval_count != null && parsed.eval_duration != null) {
+        onFinalStats?.({
+          tokens: parsed.eval_count,
+          durationMs: parsed.eval_duration / 1e6,
+        });
+      }
     }
   } catch (err) {
     if (err instanceof OllamaError) throw err;

--- a/apogee-extension/lib/engines/providers.js
+++ b/apogee-extension/lib/engines/providers.js
@@ -22,7 +22,7 @@ function sendToServiceWorker(message) {
 
 export class StreamCancelledError extends Error {}
 
-export async function* attachToStream(streamId) {
+export async function* attachToStream(streamId, { onStats } = {}) {
   const port = chrome.runtime.connect({ name: `popup-stream-${streamId}` });
   const queue = [];
   let resolvePromise = null;
@@ -34,8 +34,11 @@ export async function* attachToStream(streamId) {
   port.onMessage.addListener((msg) => {
     if (msg.type === "chunk") {
       queue.push(msg.text);
+    } else if (msg.type === "stats") {
+      onStats?.(msg.tokensPerSec);
     } else if (msg.type === "done") {
       done = true;
+      if (msg.tokensPerSec != null) onStats?.(msg.tokensPerSec);
     } else if (msg.type === "cancelled") {
       cancelled = true;
       done = true;
@@ -94,7 +97,7 @@ export function cancelStream(streamId) {
   );
 }
 
-async function startWebllmStream(action, payload) {
+async function startWebllmStream(action, payload, { onStats } = {}) {
   const { streamId } = await sendToServiceWorker({
     target: "service-worker",
     action,
@@ -103,10 +106,10 @@ async function startWebllmStream(action, payload) {
   if (!streamId) {
     throw new Error("No streamId returned from service worker");
   }
-  return { streamId, stream: attachToStream(streamId) };
+  return { streamId, stream: attachToStream(streamId, { onStats }) };
 }
 
-async function startOllamaStream(action, payload) {
+async function startOllamaStream(action, payload, { onStats } = {}) {
   const { streamId } = await sendToServiceWorker({
     target: "service-worker",
     action: "ollama-stream",
@@ -115,10 +118,10 @@ async function startOllamaStream(action, payload) {
   if (!streamId) {
     throw new Error("No streamId returned from service worker");
   }
-  return { streamId, stream: attachToStream(streamId) };
+  return { streamId, stream: attachToStream(streamId, { onStats }) };
 }
 
-async function startTransformersStream(action, payload) {
+async function startTransformersStream(action, payload, { onStats } = {}) {
   const { streamId } = await sendToServiceWorker({
     target: "service-worker",
     action: "transformers-stream",
@@ -127,10 +130,10 @@ async function startTransformersStream(action, payload) {
   if (!streamId) {
     throw new Error("No streamId returned from service worker");
   }
-  return { streamId, stream: attachToStream(streamId) };
+  return { streamId, stream: attachToStream(streamId, { onStats }) };
 }
 
-async function startLlamaCppStream(action, payload) {
+async function startLlamaCppStream(action, payload, { onStats } = {}) {
   const { streamId } = await sendToServiceWorker({
     target: "service-worker",
     action: "llamacpp-stream",
@@ -139,7 +142,7 @@ async function startLlamaCppStream(action, payload) {
   if (!streamId) {
     throw new Error("No streamId returned from service worker");
   }
-  return { streamId, stream: attachToStream(streamId) };
+  return { streamId, stream: attachToStream(streamId, { onStats }) };
 }
 
 class WebLLMProvider {
@@ -156,30 +159,39 @@ class WebLLMProvider {
     finalize,
     language,
     translationEngine,
+    onStats,
   }) {
-    return startWebllmStream("summarize", {
-      title,
-      url,
-      content,
-      mode,
-      type,
-      model: this.model,
-      finalize,
-      language,
-      translationEngine,
-    });
+    return startWebllmStream(
+      "summarize",
+      {
+        title,
+        url,
+        content,
+        mode,
+        type,
+        model: this.model,
+        finalize,
+        language,
+        translationEngine,
+      },
+      { onStats },
+    );
   }
 
-  ask({ title, url, content, question, language, translationEngine }) {
-    return startWebllmStream("ask", {
-      title,
-      url,
-      content,
-      question,
-      model: this.model,
-      language,
-      translationEngine,
-    });
+  ask({ title, url, content, question, language, translationEngine, onStats }) {
+    return startWebllmStream(
+      "ask",
+      {
+        title,
+        url,
+        content,
+        question,
+        model: this.model,
+        language,
+        translationEngine,
+      },
+      { onStats },
+    );
   }
 
   async checkReady() {
@@ -205,30 +217,39 @@ class TransformersProvider {
     finalize,
     language,
     translationEngine,
+    onStats,
   }) {
-    return startTransformersStream("summarize", {
-      title,
-      url,
-      content,
-      mode,
-      type,
-      model: this.model,
-      finalize,
-      language,
-      translationEngine,
-    });
+    return startTransformersStream(
+      "summarize",
+      {
+        title,
+        url,
+        content,
+        mode,
+        type,
+        model: this.model,
+        finalize,
+        language,
+        translationEngine,
+      },
+      { onStats },
+    );
   }
 
-  ask({ title, url, content, question, language, translationEngine }) {
-    return startTransformersStream("ask", {
-      title,
-      url,
-      content,
-      question,
-      model: this.model,
-      language,
-      translationEngine,
-    });
+  ask({ title, url, content, question, language, translationEngine, onStats }) {
+    return startTransformersStream(
+      "ask",
+      {
+        title,
+        url,
+        content,
+        question,
+        model: this.model,
+        language,
+        translationEngine,
+      },
+      { onStats },
+    );
   }
 
   async checkReady() {
@@ -255,32 +276,41 @@ class DirectOllamaProvider {
     finalize,
     language,
     translationEngine,
+    onStats,
   }) {
-    return startOllamaStream("summarize", {
-      title,
-      url,
-      content,
-      mode,
-      type,
-      model: this.model,
-      host: this.host,
-      finalize,
-      language,
-      translationEngine,
-    });
+    return startOllamaStream(
+      "summarize",
+      {
+        title,
+        url,
+        content,
+        mode,
+        type,
+        model: this.model,
+        host: this.host,
+        finalize,
+        language,
+        translationEngine,
+      },
+      { onStats },
+    );
   }
 
-  ask({ title, url, content, question, language, translationEngine }) {
-    return startOllamaStream("ask", {
-      title,
-      url,
-      content,
-      question,
-      model: this.model,
-      host: this.host,
-      language,
-      translationEngine,
-    });
+  ask({ title, url, content, question, language, translationEngine, onStats }) {
+    return startOllamaStream(
+      "ask",
+      {
+        title,
+        url,
+        content,
+        question,
+        model: this.model,
+        host: this.host,
+        language,
+        translationEngine,
+      },
+      { onStats },
+    );
   }
 
   async checkReady() {
@@ -313,34 +343,43 @@ class DirectLlamaCppProvider {
     finalize,
     language,
     translationEngine,
+    onStats,
   }) {
-    return startLlamaCppStream("summarize", {
-      title,
-      url,
-      content,
-      mode,
-      type,
-      model: this.model,
-      host: this.host,
-      apiKey: this.apiKey,
-      finalize,
-      language,
-      translationEngine,
-    });
+    return startLlamaCppStream(
+      "summarize",
+      {
+        title,
+        url,
+        content,
+        mode,
+        type,
+        model: this.model,
+        host: this.host,
+        apiKey: this.apiKey,
+        finalize,
+        language,
+        translationEngine,
+      },
+      { onStats },
+    );
   }
 
-  ask({ title, url, content, question, language, translationEngine }) {
-    return startLlamaCppStream("ask", {
-      title,
-      url,
-      content,
-      question,
-      model: this.model,
-      host: this.host,
-      apiKey: this.apiKey,
-      language,
-      translationEngine,
-    });
+  ask({ title, url, content, question, language, translationEngine, onStats }) {
+    return startLlamaCppStream(
+      "ask",
+      {
+        title,
+        url,
+        content,
+        question,
+        model: this.model,
+        host: this.host,
+        apiKey: this.apiKey,
+        language,
+        translationEngine,
+      },
+      { onStats },
+    );
   }
 
   // `contextTokens` rides along because llama-server reports the window it is

--- a/apogee-extension/lib/util/throughput.js
+++ b/apogee-extension/lib/util/throughput.js
@@ -1,0 +1,41 @@
+// ponytail: 4.7 is a heuristic average, not a real tokenizer. It only ever
+// affects a chunk longer than LONG_CHUNK_CHARS (a batched/estimated delta,
+// not a per-token one) — recalibrate if the display rate visibly drifts from
+// a backend's own self-reported rate.
+export const EST_CHARS_PER_TOKEN = 4.7;
+export const LONG_CHUNK_CHARS = 16;
+
+export const WARMUP_MIN_TOKENS = 8;
+export const WARMUP_MIN_MS = 500;
+
+export const DECIMAL_CUTOFF_TOKENS_PER_SEC = 10;
+
+export function tokensForChunk(text) {
+  if (!text) return 0;
+  return text.length <= LONG_CHUNK_CHARS
+    ? 1
+    : text.length / EST_CHARS_PER_TOKEN;
+}
+
+export function isWarmedUp(tokenCount, elapsedMs) {
+  return tokenCount >= WARMUP_MIN_TOKENS && elapsedMs >= WARMUP_MIN_MS;
+}
+
+export function tokensPerSecond(tokenCount, elapsedMs) {
+  if (elapsedMs <= 0) return 0;
+  return tokenCount / (elapsedMs / 1000);
+}
+
+export function finalTokensPerSecond({ serverStats, tokenCount, elapsedMs }) {
+  if (serverStats && serverStats.tokens > 0 && serverStats.durationMs > 0) {
+    return tokensPerSecond(serverStats.tokens, serverStats.durationMs);
+  }
+  return tokensPerSecond(tokenCount, elapsedMs);
+}
+
+export function formatTokensPerSecond(rate) {
+  if (!Number.isFinite(rate) || rate <= 0) return null;
+  return rate >= DECIMAL_CUTOFF_TOKENS_PER_SEC
+    ? `${Math.round(rate)} tok/s`
+    : `${rate.toFixed(1)} tok/s`;
+}

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -19,6 +19,12 @@ import {
   getTransformersStatus,
 } from "../lib/engines/transformersEngine.js";
 import { initDebugLogging } from "../lib/util/log.js";
+import {
+  tokensForChunk,
+  isWarmedUp,
+  tokensPerSecond,
+  finalTokensPerSecond,
+} from "../lib/util/throughput.js";
 
 initDebugLogging();
 
@@ -244,7 +250,22 @@ async function withEngine(modelId, fn, ownerStreamId = null) {
   }
 }
 
-async function* drainWebLLMStream(eng, completion, signal) {
+// WebLLM's engine can report its own decode rate on the final chunk's
+// `usage` field when the request asks for it (`stream_options.include_usage`).
+// That is more accurate than our own count, since it comes straight from the
+// engine rather than from chunk-arrival timing. Unverified against a live
+// build at time of writing: if the installed @mlc-ai/web-llm version does not
+// populate `usage.extra.decode_tokens_per_s`, this silently never fires and
+// the computed rate is used instead, which is already the designed fallback.
+function reportWebLLMFinalStats(chunk, onFinalStats) {
+  const tokens = chunk?.usage?.completion_tokens;
+  const rate = chunk?.usage?.extra?.decode_tokens_per_s;
+  if (tokens > 0 && rate > 0) {
+    onFinalStats?.({ tokens, durationMs: (tokens / rate) * 1000 });
+  }
+}
+
+async function* drainWebLLMStream(eng, completion, signal, onFinalStats) {
   let interrupted = false;
   for await (const chunk of completion) {
     if (signal?.aborted && !interrupted) {
@@ -254,10 +275,11 @@ async function* drainWebLLMStream(eng, completion, signal) {
     if (interrupted) continue;
     const text = chunk.choices?.[0]?.delta?.content || "";
     if (text) yield text;
+    reportWebLLMFinalStats(chunk, onFinalStats);
   }
 }
 
-function webllmChatFn(eng) {
+function webllmChatFn(eng, onFinalStats) {
   return async function* (prompt, { signal, system } = {}) {
     const messages = system
       ? [
@@ -268,10 +290,11 @@ function webllmChatFn(eng) {
     const completion = await eng.chat.completions.create({
       messages,
       stream: true,
+      stream_options: { include_usage: true },
       temperature: 0.3,
       max_tokens: 2048,
     });
-    yield* drainWebLLMStream(eng, completion, signal);
+    yield* drainWebLLMStream(eng, completion, signal, onFinalStats);
   };
 }
 
@@ -288,8 +311,11 @@ async function streamCompletion(
   language,
   translateFn,
 ) {
+  let serverStats = null;
   for await (const text of streamInTargetLanguage(
-    webllmChatFn(eng),
+    webllmChatFn(eng, (s) => {
+      serverStats = s;
+    }),
     prompt,
     language,
     { signal, translateFn },
@@ -297,7 +323,7 @@ async function streamCompletion(
     emit({ type: "chunk", text });
   }
 
-  emit({ type: "done" });
+  emit({ type: "done", serverStats });
 }
 
 function reportProgress(text, progress = 0) {
@@ -316,6 +342,7 @@ function opusTranslateFor(translationEngine) {
 }
 
 async function runSummarize(eng, pending, emit, signal) {
+  let serverStats = null;
   async function* webllmChatStream(_host, _model, prompt, opts) {
     const messages = opts?.system
       ? [
@@ -326,10 +353,13 @@ async function runSummarize(eng, pending, emit, signal) {
     const completion = await eng.chat.completions.create({
       messages,
       stream: true,
+      stream_options: { include_usage: true },
       temperature: 0.3,
       max_tokens: 2048,
     });
-    yield* drainWebLLMStream(eng, completion, signal);
+    yield* drainWebLLMStream(eng, completion, signal, (s) => {
+      serverStats = s;
+    });
   }
 
   const onProgress = (p) => {
@@ -370,7 +400,7 @@ async function runSummarize(eng, pending, emit, signal) {
   )) {
     emit({ type: "chunk", text: token });
   }
-  emit({ type: "done" });
+  emit({ type: "done", serverStats });
 }
 
 const streams = new Map();
@@ -499,13 +529,41 @@ async function runStream(streamId, pending, stream) {
 
   const emit = (msg) => {
     if (stream.cancelled) return;
-    if (msg.type === "chunk") stream.text += msg.text || "";
-    if (msg.type === "done") stream.done = true;
+    if (msg.type === "chunk") {
+      stream.text += msg.text || "";
+      if (stream.firstTokenTime == null) {
+        stream.firstTokenTime = performance.now();
+      }
+      stream.tokenCount += tokensForChunk(msg.text);
+    }
+    if (msg.type === "done") {
+      stream.done = true;
+      const elapsedMs =
+        stream.firstTokenTime != null
+          ? performance.now() - stream.firstTokenTime
+          : 0;
+      stream.tokensPerSec =
+        finalTokensPerSecond({
+          serverStats: msg.serverStats ?? null,
+          tokenCount: stream.tokenCount,
+          elapsedMs,
+        }) || null;
+      msg = { ...msg, tokensPerSec: stream.tokensPerSec };
+    }
     if (msg.type === "error") {
       stream.error = msg.error;
       stream.done = true;
     }
     broadcastToStream(stream, msg);
+    if (msg.type === "chunk" && stream.firstTokenTime != null) {
+      const elapsedMs = performance.now() - stream.firstTokenTime;
+      if (isWarmedUp(stream.tokenCount, elapsedMs)) {
+        broadcastToStream(stream, {
+          type: "stats",
+          tokensPerSec: tokensPerSecond(stream.tokenCount, elapsedMs),
+        });
+      }
+    }
 
     if (
       msg.type === "done" &&
@@ -648,8 +706,18 @@ chrome.runtime.onConnect.addListener((port) => {
     } catch {}
   } else if (stream.done) {
     try {
-      port.postMessage({ type: "done" });
+      port.postMessage({ type: "done", tokensPerSec: stream.tokensPerSec });
     } catch {}
+  } else if (stream.firstTokenTime != null) {
+    const elapsedMs = performance.now() - stream.firstTokenTime;
+    if (isWarmedUp(stream.tokenCount, elapsedMs)) {
+      try {
+        port.postMessage({
+          type: "stats",
+          tokensPerSec: tokensPerSecond(stream.tokenCount, elapsedMs),
+        });
+      } catch {}
+    }
   }
 
   port.onDisconnect.addListener(() => {
@@ -674,6 +742,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             error: null,
             cancelled: false,
             subscribers: new Set(),
+            tokenCount: 0,
+            firstTokenTime: null,
+            tokensPerSec: null,
           };
           streams.set(streamId, stream);
           sendResponse({ streamId });

--- a/apogee-extension/popup/popup.css
+++ b/apogee-extension/popup/popup.css
@@ -492,7 +492,8 @@ body {
   gap: 8px;
 }
 
-.time-saved-badge {
+.time-saved-badge,
+.tokens-per-sec-badge {
   padding: 3px 8px;
   background: var(--badge-bg);
   color: var(--badge-text);
@@ -563,8 +564,8 @@ body {
 }
 
 .summary-footer:not(:has(.time-saved-badge:not(.hidden))):not(
-    :has(.summary-footer-actions button:not(.hidden))
-  ) {
+    :has(.tokens-per-sec-badge:not(.hidden))
+  ):not(:has(.summary-footer-actions button:not(.hidden))) {
   margin-top: 0;
 }
 
@@ -598,10 +599,23 @@ body {
   cursor: default;
 }
 
+.ask-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.ask-footer:not(:has(.tokens-per-sec-badge:not(.hidden))):not(
+    :has(#cancelAskBtn:not(.hidden))
+  ) {
+  margin-top: 0;
+}
+
 #cancelAskBtn {
   display: block;
   width: fit-content;
-  margin: 12px 0 0 auto;
 }
 
 .resummarize-btn {

--- a/apogee-extension/popup/popup.html
+++ b/apogee-extension/popup/popup.html
@@ -307,6 +307,10 @@
 
             <div class="summary-footer">
               <span id="timeSavedBadge" class="time-saved-badge hidden"></span>
+              <span
+                id="tokensPerSecBadgeSummary"
+                class="tokens-per-sec-badge hidden"
+              ></span>
 
               <div class="summary-footer-actions">
                 <button
@@ -390,9 +394,15 @@
 
               <div id="answerBox" class="answer-box hidden"></div>
 
-              <button id="cancelAskBtn" class="cancel-btn hidden">
-                Cancel
-              </button>
+              <div class="ask-footer">
+                <span
+                  id="tokensPerSecBadgeAsk"
+                  class="tokens-per-sec-badge hidden"
+                ></span>
+                <button id="cancelAskBtn" class="cancel-btn hidden">
+                  Cancel
+                </button>
+              </div>
             </div>
           </section>
         </div>

--- a/apogee-extension/popup/popup.js
+++ b/apogee-extension/popup/popup.js
@@ -44,6 +44,7 @@ import {
   timeSavedInputsFor,
   formatTimeSavedFromInputs,
 } from "../lib/util/readingTime.js";
+import { formatTokensPerSecond } from "../lib/util/throughput.js";
 import {
   saveViewState,
   saveViewStateIfJobMatches,
@@ -132,11 +133,15 @@ const resummarizeHint = document.getElementById("resummarizeHint");
 const resummarizeHintText = document.getElementById("resummarizeHintText");
 const resummarizeHintBtn = document.getElementById("resummarizeHintBtn");
 const timeSavedBadge = document.getElementById("timeSavedBadge");
+const tokensPerSecBadgeSummary = document.getElementById(
+  "tokensPerSecBadgeSummary",
+);
 const copySummaryBtn = document.getElementById("copySummaryBtn");
 const copyMarkdownBtn = document.getElementById("copyMarkdownBtn");
 const copyPlainTextBtn = document.getElementById("copyPlainTextBtn");
 const copyAnswerBtn = document.getElementById("copyAnswerBtn");
 const cancelAskBtn = document.getElementById("cancelAskBtn");
+const tokensPerSecBadgeAsk = document.getElementById("tokensPerSecBadgeAsk");
 const pastSummariesSection = document.getElementById("pastSummariesSection");
 const pastSummariesList = document.getElementById("pastSummariesList");
 const pastSummariesFilter = document.getElementById("pastSummariesFilter");
@@ -1141,6 +1146,7 @@ function showSummarizingContext() {
   togglePromptsBtn.style.display = "none";
   setSummaryCopyButtonsVisible(false);
   updateTimeSavedBadge(null, null);
+  setTokensPerSecBadge(tokensPerSecBadgeSummary, null);
 }
 
 function setTimeSavedBadgeLabel(label) {
@@ -1158,6 +1164,13 @@ function updateTimeSavedBadge(pageData, summaryText) {
 
 function showTimeSavedFromInputs(inputs, summaryText) {
   setTimeSavedBadgeLabel(formatTimeSavedFromInputs(inputs, summaryText));
+}
+
+function setTokensPerSecBadge(el, rate) {
+  if (!el) return;
+  const label = rate != null ? formatTokensPerSecond(rate) : null;
+  el.textContent = label || "";
+  el.classList.toggle("hidden", !label);
 }
 
 function setSummaryCopyButtonsVisible(hasText) {
@@ -1322,6 +1335,7 @@ function showAskContext() {
   answerBox.textContent = "";
   togglePromptsBtn.style.display = "none";
   copyAnswerBtn.classList.add("hidden");
+  setTokensPerSecBadge(tokensPerSecBadgeAsk, null);
 }
 
 function showAnswerContext(question) {
@@ -1343,6 +1357,7 @@ function showAnswerContext(question) {
   answerBox.classList.remove("hidden");
   copyAnswerBtn.classList.add("hidden");
   setLoadingIndicator(answerBox, "Thinking");
+  setTokensPerSecBadge(tokensPerSecBadgeAsk, null);
 }
 
 function showCancelAskButton(streamId) {
@@ -1552,6 +1567,7 @@ async function summarizeActivePage() {
         language: settings.summaryLanguage,
         translationEngine: settings.translationEngine,
         finalize,
+        onStats: (rate) => setTokensPerSecBadge(tokensPerSecBadgeSummary, rate),
       }));
     } else {
       ({ streamId, stream } = await provider.summarize({
@@ -1563,6 +1579,7 @@ async function summarizeActivePage() {
         language: settings.summaryLanguage,
         translationEngine: settings.translationEngine,
         finalize,
+        onStats: (rate) => setTokensPerSecBadge(tokensPerSecBadgeSummary, rate),
       }));
     }
 
@@ -1690,6 +1707,7 @@ async function submitQuestion(question) {
       question: trimmed,
       language: settings.summaryLanguage,
       translationEngine: settings.translationEngine,
+      onStats: (rate) => setTokensPerSecBadge(tokensPerSecBadgeAsk, rate),
     });
 
     await saveViewState(tab.id, {
@@ -1904,11 +1922,17 @@ document.addEventListener("DOMContentLoaded", async () => {
         let resumeFromCompletedState = false;
         try {
           await getPageData(tab);
-          await consumeSummaryStream(attachToStream(state.streamId), {
-            tab,
-            promptsCacheKey: state.promptsCacheKey,
-            jobId: state.jobId,
-          });
+          await consumeSummaryStream(
+            attachToStream(state.streamId, {
+              onStats: (rate) =>
+                setTokensPerSecBadge(tokensPerSecBadgeSummary, rate),
+            }),
+            {
+              tab,
+              promptsCacheKey: state.promptsCacheKey,
+              jobId: state.jobId,
+            },
+          );
         } catch (error) {
           if (error instanceof StreamCancelledError) {
             await returnHomeAfterCancel(tab.id, state.jobId);
@@ -1948,10 +1972,16 @@ document.addEventListener("DOMContentLoaded", async () => {
         showAnswerContext(state.question || "");
         showCancelAskButton(state.streamId);
         try {
-          await consumeAnswerStream(attachToStream(state.streamId), {
-            tab,
-            question: state.question || "",
-          });
+          await consumeAnswerStream(
+            attachToStream(state.streamId, {
+              onStats: (rate) =>
+                setTokensPerSecBadge(tokensPerSecBadgeAsk, rate),
+            }),
+            {
+              tab,
+              question: state.question || "",
+            },
+          );
         } catch (error) {
           if (error instanceof StreamCancelledError) {
             returnToAskAfterCancel(tab.id);
@@ -2165,6 +2195,7 @@ async function summarizeCustomContent(title, content, url = "") {
       language: settings.summaryLanguage,
       customInstructions: settings.customInstructions,
       translationEngine: settings.translationEngine,
+      onStats: (rate) => setTokensPerSecBadge(tokensPerSecBadgeSummary, rate),
     });
 
     activeSummarizeStreamId = streamId;

--- a/apogee-extension/tests/engines/attachToStream.test.js
+++ b/apogee-extension/tests/engines/attachToStream.test.js
@@ -39,6 +39,61 @@ test("attachToStream yields buffered chunks and completes on a normal done+disco
   assert.deepStrictEqual(await resultsPromise, ["hello ", "world"]);
 });
 
+test("attachToStream reports a live stats message through onStats", async () => {
+  const port = createFakePort();
+  globalThis.chrome = { runtime: { connect: () => port } };
+
+  const received = [];
+  const resultsPromise = collect(
+    attachToStream("stream-stats", { onStats: (rate) => received.push(rate) }),
+  );
+  await new Promise((r) => setTimeout(r, 0));
+
+  port._emitMessage({ type: "chunk", text: "hello" });
+  port._emitMessage({ type: "stats", tokensPerSec: 12.5 });
+  port._emitMessage({ type: "done" });
+  port._emitDisconnect();
+
+  await resultsPromise;
+  assert.deepStrictEqual(received, [12.5]);
+});
+
+test("attachToStream reports the frozen rate on a done message with tokensPerSec", async () => {
+  const port = createFakePort();
+  globalThis.chrome = { runtime: { connect: () => port } };
+
+  const received = [];
+  const resultsPromise = collect(
+    attachToStream("stream-frozen", { onStats: (rate) => received.push(rate) }),
+  );
+  await new Promise((r) => setTimeout(r, 0));
+
+  port._emitMessage({ type: "chunk", text: "hello" });
+  port._emitMessage({ type: "done", tokensPerSec: 30 });
+  port._emitDisconnect();
+
+  await resultsPromise;
+  assert.deepStrictEqual(received, [30]);
+});
+
+test("attachToStream does not call onStats for a done message with no tokensPerSec", async () => {
+  const port = createFakePort();
+  globalThis.chrome = { runtime: { connect: () => port } };
+
+  let called = false;
+  const resultsPromise = collect(
+    attachToStream("stream-no-stats", { onStats: () => (called = true) }),
+  );
+  await new Promise((r) => setTimeout(r, 0));
+
+  port._emitMessage({ type: "chunk", text: "hello" });
+  port._emitMessage({ type: "done" });
+  port._emitDisconnect();
+
+  await resultsPromise;
+  assert.strictEqual(called, false);
+});
+
 test("attachToStream surfaces the sender's error message instead of swallowing it", async () => {
   const port = createFakePort();
   globalThis.chrome = { runtime: { connect: () => port } };

--- a/apogee-extension/tests/engines/llamaCppClient.test.js
+++ b/apogee-extension/tests/engines/llamaCppClient.test.js
@@ -131,6 +131,48 @@ for (const { name, chunks, expected } of STREAM_CASES) {
   });
 }
 
+test("chatStream reports timings via onFinalStats when the server sends predicted_n", async () => {
+  const finalEvent = event({
+    choices: [{ finish_reason: "stop", index: 0, delta: {} }],
+    timings: { predicted_n: 84, predicted_ms: 3000 },
+  });
+  const restore = stubFetch(async () =>
+    streamingResponse([token("hi"), finalEvent, "data: [DONE]"]),
+  );
+  let stats = null;
+  try {
+    await collect(
+      chatStream(HOST, "test-model", "prompt", {
+        onFinalStats: (s) => {
+          stats = s;
+        },
+      }),
+    );
+  } finally {
+    restore();
+  }
+  assert.deepStrictEqual(stats, { tokens: 84, durationMs: 3000 });
+});
+
+test("chatStream does not call onFinalStats when timings has no predicted_n", async () => {
+  const restore = stubFetch(async () =>
+    streamingResponse([token("hi"), STOP, "data: [DONE]"]),
+  );
+  let called = false;
+  try {
+    await collect(
+      chatStream(HOST, "test-model", "prompt", {
+        onFinalStats: () => {
+          called = true;
+        },
+      }),
+    );
+  } finally {
+    restore();
+  }
+  assert.strictEqual(called, false);
+});
+
 test("chatStream throws rather than silently skipping a malformed data payload", async () => {
   const restore = stubFetch(async () =>
     streamingResponse([token("fine"), "data: {not json}\n\n"]),

--- a/apogee-extension/tests/engines/ollamaClient.test.js
+++ b/apogee-extension/tests/engines/ollamaClient.test.js
@@ -110,6 +110,37 @@ test("chatStream: streams content chunks successfully", async (t) => {
   ]);
 });
 
+test("chatStream: reports eval_count/eval_duration via onFinalStats", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = async () => {
+    const ndjson = [
+      JSON.stringify({ message: { content: "Hi" } }) + "\n",
+      JSON.stringify({
+        message: { content: "" },
+        done: true,
+        eval_count: 42,
+        eval_duration: 2_000_000_000,
+      }) + "\n",
+    ];
+    return createMockStreamResponse(ndjson);
+  };
+
+  let stats = null;
+  await collectStream(
+    chatStream("http://127.0.0.1:11434", "llama3.2", "Hi", {
+      onFinalStats: (s) => {
+        stats = s;
+      },
+    }),
+  );
+
+  assert.deepStrictEqual(stats, { tokens: 42, durationMs: 2000 });
+});
+
 test("chatStream: handles non-OK HTTP status with JSON error payload", async (t) => {
   const originalFetch = globalThis.fetch;
   t.after(() => {

--- a/apogee-extension/tests/util/throughput.test.js
+++ b/apogee-extension/tests/util/throughput.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert";
+import {
+  EST_CHARS_PER_TOKEN,
+  tokensForChunk,
+  isWarmedUp,
+  tokensPerSecond,
+  finalTokensPerSecond,
+  formatTokensPerSecond,
+} from "../../lib/util/throughput.js";
+
+test("tokensForChunk counts a short chunk as one token", () => {
+  assert.strictEqual(tokensForChunk("Hello"), 1);
+});
+
+test("tokensForChunk estimates a long, batched chunk from its length", () => {
+  const text = "a".repeat(32);
+  assert.strictEqual(tokensForChunk(text), text.length / EST_CHARS_PER_TOKEN);
+});
+
+test("tokensForChunk treats empty or nullish text as zero tokens", () => {
+  assert.strictEqual(tokensForChunk(""), 0);
+  assert.strictEqual(tokensForChunk(null), 0);
+  assert.strictEqual(tokensForChunk(undefined), 0);
+});
+
+test("isWarmedUp is false until both the token and time thresholds clear", () => {
+  assert.strictEqual(isWarmedUp(7, 1000), false);
+  assert.strictEqual(isWarmedUp(8, 499), false);
+  assert.strictEqual(isWarmedUp(8, 500), true);
+  assert.strictEqual(isWarmedUp(20, 2000), true);
+});
+
+test("tokensPerSecond divides tokens by elapsed seconds", () => {
+  assert.strictEqual(tokensPerSecond(28, 1000), 28);
+});
+
+test("tokensPerSecond returns zero for a non-positive elapsed time", () => {
+  assert.strictEqual(tokensPerSecond(10, 0), 0);
+  assert.strictEqual(tokensPerSecond(10, -5), 0);
+});
+
+test("finalTokensPerSecond prefers server-reported stats when valid", () => {
+  const rate = finalTokensPerSecond({
+    serverStats: { tokens: 100, durationMs: 2000 },
+    tokenCount: 40,
+    elapsedMs: 1000,
+  });
+  assert.strictEqual(rate, 50);
+});
+
+test("finalTokensPerSecond falls back to the computed rate without server stats", () => {
+  const rate = finalTokensPerSecond({
+    serverStats: null,
+    tokenCount: 40,
+    elapsedMs: 2000,
+  });
+  assert.strictEqual(rate, 20);
+});
+
+test("finalTokensPerSecond falls back when server stats are incomplete", () => {
+  const rate = finalTokensPerSecond({
+    serverStats: { tokens: 0, durationMs: 2000 },
+    tokenCount: 40,
+    elapsedMs: 2000,
+  });
+  assert.strictEqual(rate, 20);
+});
+
+test("formatTokensPerSecond keeps a decimal only where it carries meaning", () => {
+  assert.strictEqual(formatTokensPerSecond(3.456), "3.5 tok/s");
+  assert.strictEqual(formatTokensPerSecond(9.99), "10.0 tok/s");
+  assert.strictEqual(formatTokensPerSecond(10), "10 tok/s");
+  assert.strictEqual(formatTokensPerSecond(27.6), "28 tok/s");
+});
+
+test("formatTokensPerSecond renders nothing rather than a placeholder", () => {
+  assert.strictEqual(formatTokensPerSecond(0), null);
+  assert.strictEqual(formatTokensPerSecond(-1), null);
+  assert.strictEqual(formatTokensPerSecond(NaN), null);
+});


### PR DESCRIPTION
Measures live generation throughput for every provider and freezes the final number on completion, so speed is visible and comparable across WebLLM, in-browser WASM, Ollama, and llama.cpp.

Counting lives in the background (service worker for Ollama/llama.cpp and Firefox's WASM path, the offscreen document for WebLLM and Chrome's WASM path) rather than the popup, since a popup that closes and reopens mid-stream only gets replayed the buffered text, not the original per-token timing.

Each engine already streams one token per chunk, so counting chunks is exact; only an oversized (batched) chunk falls back to a length-based estimate. The clock starts at the first token rather than at request-send, so model load and prompt processing aren't counted against the rate.

The frozen final number prefers a backend's own self-reported rate (Ollama's eval_count/eval_duration, llama.cpp's timings, WebLLM's usage extras when available) over our computed one, since those exclude network transit. All three are wired through an additive, optional onFinalStats callback that leaves the existing streaming contract unchanged; where a backend doesn't report it, the computed rate is used instead.

Closes #145

## Summary

- Live `tok/s` reading next to the time-saved badge (summary) and the cancel button (ask), updating while streaming and frozen on completion.
- Token counting and timing live in the background (service worker / offscreen document), not the popup, so a popup close/reopen mid-stream still shows a correct live and frozen number instead of restarting from zero.
- The frozen number prefers each backend's own self-reported rate (Ollama's `eval_count`/`eval_duration`, llama.cpp's `timings`) when available, verified end-to-end against a live `llama-server` (b10603, Qwen2.5-0.5B): our chunk-counted total was within ~1% of the server's own count, and the final display correctly used the server's rate.
- No "WebGPU" label anywhere — `transformersEngine.js` hardcodes `device: "wasm"`, so there's no live WebGPU generation path to report on today.

## Test plan

- [x] `npm run format:check` (files touched by this PR are clean; verified the committed blobs are LF-only, the local CRLF warnings are this machine's `core.autocrlf=true` on checkout, not the actual commit content)
- [x] `npm run lint`
- [x] `npm test` (415 tests, 413 passing; the 2 failures are pre-existing and unrelated — a Windows path-with-space issue in `manifest.test.js` that reproduces identically with this branch's changes stashed out)
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [x] Manually exercised the change in a loaded browser extension

## Privacy impact

- [x] No new outbound network calls (added fields ride on requests already being made to the same hosts — no new endpoint or host contacted)

<!-- Permissions and network behaviour are described in four places that must
     agree: apogee-extension/manifest.json, README.md (Privacy & Permissions),
     PRIVACY.md, and store-listing.md (permission justifications). A claim in
     one and not the others is what store reviewers catch. -->

- [x] Permissions unchanged, or all four of manifest / README / PRIVACY /
      store-listing updated together
