### PR TITLE
feat(summarize): hierarchical map-reduce for long inputs (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Translation engine cache identity.** Included translation engine in cached summary identity keys to prevent cache collisions between LLM and Opus-MT translation outputs. (#100, #101)
 - **Stream expiry summary recovery.** Restored ability to view completed summaries when reopening popup after stream expiry.
 
+### Changed
+
+- **Hierarchical map-reduce for long inputs.** Replaced the `stratifiedSample` fallback in `lib/summarize/mapReduce.js` with a bottom-up tree reduction: when an input produces more chunks than the model's `getMaxChunks` budget (4 for Transformers.js, 12 for Ollama), every chunk is now mapped, then partials are folded in groups of `fanIn` until fewer than `maxChunks` remain, then a final reduce runs. This preserves comprehensive coverage of long articles, transcripts, and threads instead of silently dropping ~75% of the material. The `{ stage: "truncated" }` progress event no longer fires on overflow by default; it only fires when an injected `selectChunksFn` returns fewer chunks than the input supplied. The `{ stage: "reduce", depth, index, total }` event is new for intermediate tree-reduce calls; the final reduce event still has no `depth` field. A custom `selectChunksFn` still wins over the tree when provided. (#148)
+
 ### Security
 
 - **Removed exposed global scope objects.** Neutralized `window.__apogeeHighlight` and `window.extractPageContent` global function exposures in content scripts, replacing them with secure `chrome.runtime` / `chrome.tabs` message listeners. (#121, #122)

--- a/apogee-extension/lib/summarize/mapReduce.js
+++ b/apogee-extension/lib/summarize/mapReduce.js
@@ -16,7 +16,8 @@ function isOomError(err) {
 // intermediates remain, then run the final reduce. Each group emits
 // its own streamed partial, so the consumer can interleave or buffer.
 function pickFanIn(partialCount, maxChunks) {
-  if (partialCount <= maxChunks) return partialCount;
+  // Caller guarantees partialCount > maxChunks (while guard in reduceTree),
+  // so no need for the <= branch.
   return Math.max(2, Math.ceil(partialCount / maxChunks));
 }
 
@@ -130,13 +131,7 @@ async function reduceTree({
       let merged;
       try {
         merged = await collectStream(
-          streamReduceStep(
-            chatStreamFn,
-            host,
-            model,
-            group,
-            stepOpts,
-          ),
+          streamReduceStep(chatStreamFn, host, model, group, stepOpts),
         );
       } catch (err) {
         if (isOomError(err)) {
@@ -144,6 +139,11 @@ async function reduceTree({
           return [...next, ...current.slice(i)];
         }
         throw err;
+      }
+      // OOM signaled via onOom inside streamReduceStep does not throw;
+      // treat it as failure of this group and preserve its originals.
+      if (hitOom) {
+        return [...next, ...current.slice(i)];
       }
       const trimmed = merged.trim();
       if (trimmed) next.push(trimmed);
@@ -172,12 +172,7 @@ export async function* mapReduceStream(
 
   const maxChunks = getMaxChunks(model);
   if (chunks.length > maxChunks) {
-    chunks = choosePartialChunks(
-      chunks,
-      maxChunks,
-      selectChunksFn,
-      onProgress,
-    );
+    chunks = choosePartialChunks(chunks, maxChunks, selectChunksFn, onProgress);
   }
   if (signal?.aborted) return;
 
@@ -250,5 +245,21 @@ export async function* mapReduceStream(
   if (signal?.aborted) return;
   if (intermediates.length === 0) return;
   onProgress?.({ stage: "reduce" });
-  yield* streamFinal(buildReduce(intermediates));
+  try {
+    yield* streamFinal(buildReduce(intermediates));
+  } catch (err) {
+    if (isOomError(err)) {
+      onProgress?.({ stage: "oom_fallback", index: -1 });
+      // Final reduce OOM means even the folded intermediates are too large
+      // (e.g. tree was aborted mid-way and intermediates > maxChunks).
+      // Fall back to streaming the concatenated partials without a model
+      // call so the user still gets coverage of every chunk.
+      for (const p of intermediates) {
+        if (signal?.aborted) return;
+        yield p + "\n\n";
+      }
+      return;
+    }
+    throw err;
+  }
 }

--- a/apogee-extension/lib/summarize/mapReduce.js
+++ b/apogee-extension/lib/summarize/mapReduce.js
@@ -2,12 +2,157 @@ import { cleanText } from "./cleaner.js";
 import { getMaxChunkChars, getMaxChunks } from "../engines/modelLimits.js";
 import { streamInTargetLanguage } from "../language/languageOutput.js";
 
-function stratifiedSample(chunks, k) {
-  if (chunks.length <= k) return chunks;
-  const step = chunks.length / k;
-  const picked = [];
-  for (let i = 0; i < k; i++) picked.push(chunks[Math.floor(i * step)]);
-  return picked;
+const OOM_PATTERN =
+  /out of memory|oom|buffer allocation|gpubuffer|allocation failed|memory limit/i;
+
+function isOomError(err) {
+  return OOM_PATTERN.test(err?.message || "");
+}
+
+// For a long input that exceeds the model's chunk budget, the previous
+// pipeline silently dropped chunks via stratified sampling. Now we keep
+// full coverage: map every chunk to a partial, then tree-fold the
+// partials in groups of `fanIn` until fewer than `maxChunks`
+// intermediates remain, then run the final reduce. Each group emits
+// its own streamed partial, so the consumer can interleave or buffer.
+function pickFanIn(partialCount, maxChunks) {
+  if (partialCount <= maxChunks) return partialCount;
+  return Math.max(2, Math.ceil(partialCount / maxChunks));
+}
+
+function choosePartialChunks(chunks, maxChunks, selectChunksFn, onProgress) {
+  if (chunks.length <= maxChunks) return chunks;
+  if (selectChunksFn) {
+    try {
+      const selected = selectChunksFn(chunks, maxChunks);
+      if (Array.isArray(selected) && selected.length) {
+        if (selected.length < chunks.length) {
+          onProgress?.({
+            stage: "truncated",
+            kept: selected.length,
+            total: chunks.length,
+          });
+        }
+        return selected;
+      }
+    } catch {
+      // Fall through to the default.
+    }
+  }
+  // No selector (or it failed): keep every chunk and rely on the
+  // tree-reduce stage to fold the surplus. The point of issue #148 is
+  // exactly that "drop material you don't have time to map" is the
+  // wrong default.
+  return chunks;
+}
+
+async function* streamReduceStep(chatStreamFn, host, model, partials, opts) {
+  const { signal, buildReduce, depth, onProgress, index, total } = opts;
+  if (signal?.aborted) return "";
+  onProgress?.({ stage: "reduce", depth, index, total });
+  let out = "";
+  try {
+    for await (const token of chatStreamFn(host, model, buildReduce(partials), {
+      signal,
+    })) {
+      if (signal?.aborted) return out;
+      yield token;
+      out += token;
+    }
+  } catch (err) {
+    if (signal?.aborted || isOomError(err)) {
+      // OOM mid-reduce: signal the caller and stop the tree. The
+      // outer driver will fall back to a final reduce with whatever
+      // partials we have accumulated.
+      if (isOomError(err)) {
+        opts.onOom?.(err);
+      }
+      return out;
+    }
+    throw err;
+  }
+  return out;
+}
+
+async function collectStream(generator) {
+  let out = "";
+  for await (const token of generator) {
+    out += token;
+  }
+  return out;
+}
+
+async function reduceTree({
+  partials,
+  maxChunks,
+  host,
+  model,
+  signal,
+  buildReduce,
+  chatStreamFn,
+  onProgress,
+  onOom,
+}) {
+  // Tree-reduce partials in groups of `fanIn` until fewer than
+  // `maxChunks` remain. Each round is one model call per group; the
+  // final round is also a model call but produces the streamed
+  // output the caller ultimately sees.
+  //
+  // An OOM during the tree is treated the same way as an OOM during
+  // the map stage: bail out and use whatever partials we have
+  // already produced (plus any still-unmerged groups) so the caller
+  // still gets a streamed final reduce instead of nothing.
+  let current = partials;
+  let depth = 1;
+  let hitOom = false;
+  while (current.length > maxChunks) {
+    if (signal?.aborted) return current;
+    const fanIn = pickFanIn(current.length, maxChunks);
+    const next = [];
+    const total = Math.ceil(current.length / fanIn);
+    for (let i = 0; i < current.length; i += fanIn) {
+      if (signal?.aborted || hitOom) {
+        return [...next, ...current.slice(i)];
+      }
+      const group = current.slice(i, i + fanIn);
+      const stepOpts = {
+        signal,
+        buildReduce,
+        depth,
+        onProgress,
+        index: Math.floor(i / fanIn),
+        total,
+        onOom: (err) => {
+          hitOom = true;
+          onOom?.(err);
+        },
+      };
+      let merged;
+      try {
+        merged = await collectStream(
+          streamReduceStep(
+            chatStreamFn,
+            host,
+            model,
+            group,
+            stepOpts,
+          ),
+        );
+      } catch (err) {
+        if (isOomError(err)) {
+          stepOpts.onOom(err);
+          return [...next, ...current.slice(i)];
+        }
+        throw err;
+      }
+      const trimmed = merged.trim();
+      if (trimmed) next.push(trimmed);
+    }
+    if (next.length === 0) return current;
+    current = next;
+    depth += 1;
+  }
+  return current;
 }
 
 export async function* mapReduceStream(
@@ -27,19 +172,12 @@ export async function* mapReduceStream(
 
   const maxChunks = getMaxChunks(model);
   if (chunks.length > maxChunks) {
-    onProgress?.({ stage: "truncated", kept: maxChunks, total: chunks.length });
-    let selected = null;
-    if (selectChunksFn) {
-      try {
-        selected = await selectChunksFn(chunks, maxChunks);
-      } catch {
-        selected = null;
-      }
-    }
-    chunks =
-      Array.isArray(selected) && selected.length
-        ? selected
-        : stratifiedSample(chunks, maxChunks);
+    chunks = choosePartialChunks(
+      chunks,
+      maxChunks,
+      selectChunksFn,
+      onProgress,
+    );
   }
   if (signal?.aborted) return;
 
@@ -59,6 +197,7 @@ export async function* mapReduceStream(
   }
 
   const partials = [];
+  let hitOom = false;
   for (let i = 0; i < chunks.length; i++) {
     if (signal?.aborted) return;
     onProgress?.({ stage: "map", index: i, total: chunks.length });
@@ -78,12 +217,8 @@ export async function* mapReduceStream(
       }
     } catch (err) {
       if (signal?.aborted) return;
-      // If OOM or resource limit hit on a chunk, keep partials collected so far
-      const isOOM =
-        /out of memory|oom|buffer allocation|gpubuffer|allocation failed|memory limit/i.test(
-          err?.message || "",
-        );
-      if (isOOM && partials.length > 0) {
+      if (isOomError(err)) {
+        hitOom = true;
         onProgress?.({ stage: "oom_fallback", index: i });
         break;
       }
@@ -93,6 +228,27 @@ export async function* mapReduceStream(
 
   if (signal?.aborted) return;
   if (partials.length === 0) return;
+
+  let intermediates = partials;
+  if (!hitOom && intermediates.length > maxChunks) {
+    intermediates = await reduceTree({
+      partials: intermediates,
+      maxChunks,
+      host,
+      model,
+      signal,
+      buildReduce,
+      chatStreamFn,
+      onProgress,
+      onOom: (_err) => {
+        hitOom = true;
+        onProgress?.({ stage: "oom_fallback", index: -1 });
+      },
+    });
+  }
+
+  if (signal?.aborted) return;
+  if (intermediates.length === 0) return;
   onProgress?.({ stage: "reduce" });
-  yield* streamFinal(buildReduce(partials));
+  yield* streamFinal(buildReduce(intermediates));
 }

--- a/apogee-extension/tests/summarize/mapReduce.test.js
+++ b/apogee-extension/tests/summarize/mapReduce.test.js
@@ -29,7 +29,8 @@ function makePrompts() {
   return {
     buildSingle: (chunk) => `SINGLE: ${chunk}`,
     buildMap: (chunk, i, total) => `MAP[${i}/${total}]: ${chunk}`,
-    buildReduce: (partials) => `REDUCE(${partials.length}): ${partials.join(" | ")}`,
+    buildReduce: (partials) =>
+      `REDUCE(${partials.length}): ${partials.join(" | ")}`,
   };
 }
 
@@ -118,8 +119,15 @@ test("mapReduceStream: 13 chunks, budget 12 → 13 map + 1 reduce of all 13 (no 
   // Exactly one final reduce event, and >= 1 intermediate reduce event.
   const reduces = progress.filter((p) => p.stage === "reduce");
   const intermediate = reduces.filter((p) => p.depth === 1);
-  assert.ok(intermediate.length >= 1, "expected at least one intermediate reduce event");
-  assert.strictEqual(reduces[reduces.length - 1].depth, undefined, "final reduce has no depth");
+  assert.ok(
+    intermediate.length >= 1,
+    "expected at least one intermediate reduce event",
+  );
+  assert.strictEqual(
+    reduces[reduces.length - 1].depth,
+    undefined,
+    "final reduce has no depth",
+  );
 });
 
 test("mapReduceStream: 48 chunks, budget 12 → 48 map + 12 first-level reduce + 1 final reduce (fanIn=4)", async () => {
@@ -164,12 +172,18 @@ test("mapReduceStream: 48 chunks, budget 12 → 48 map + 12 first-level reduce +
   // The first reduce must come after all maps.
   const firstReduceIdx = stages.indexOf("r1");
   const lastMapIdx = stages.lastIndexOf("m");
-  assert.ok(firstReduceIdx > lastMapIdx, "intermediate reduce must follow all maps");
+  assert.ok(
+    firstReduceIdx > lastMapIdx,
+    "intermediate reduce must follow all maps",
+  );
 
   // The final reduce must come after all intermediate reduces.
   const finalReduceIdx = stages.indexOf("rf");
   const lastR1Idx = stages.lastIndexOf("r1");
-  assert.ok(finalReduceIdx > lastR1Idx, "final reduce must follow intermediate reduces");
+  assert.ok(
+    finalReduceIdx > lastR1Idx,
+    "final reduce must follow intermediate reduces",
+  );
 });
 
 test("mapReduceStream: 24 chunks, budget 12 → fanIn=2 → 24 map + 12 reduce + 1 final", async () => {
@@ -179,7 +193,11 @@ test("mapReduceStream: 24 chunks, budget 12 → fanIn=2 → 24 map + 12 reduce +
   await collect(
     mapReduceStream(
       { text: "irrelevant", model: "m", host: "h" },
-      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: NOOP_PROGRESS,
+      },
       makePrompts(),
     ),
   );
@@ -210,12 +228,15 @@ test("mapReduceStream: tree-reduce groups partials in input order", async () => 
   await collect(
     mapReduceStream(
       { text: "irrelevant", model: "m", host: "h" },
-      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: NOOP_PROGRESS,
+      },
       {
         buildSingle: (c) => `SINGLE: ${c}`,
         buildMap: (c, i, t) => `MAP[${i}/${t}]: ${c}`,
-        buildReduce: (ps) =>
-          `REDUCE(${ps.length}): ${ps.join(" || ")}`,
+        buildReduce: (ps) => `REDUCE(${ps.length}): ${ps.join(" || ")}`,
       },
     ),
   );
@@ -231,12 +252,15 @@ test("mapReduceStream: tree-reduce groups partials in input order", async () => 
         model: "HuggingFaceTB/SmolLM2-360M-Instruct",
         host: "h",
       },
-      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: NOOP_PROGRESS,
+      },
       {
         buildSingle: (c) => `SINGLE: ${c}`,
         buildMap: (c, i, t) => `MAP[${i}/${t}]: ${c}`,
-        buildReduce: (ps) =>
-          `REDUCE(${ps.length}): ${ps.join(" || ")}`,
+        buildReduce: (ps) => `REDUCE(${ps.length}): ${ps.join(" || ")}`,
       },
     ),
   );
@@ -274,7 +298,11 @@ test("mapReduceStream: intermediate reduce tokens reach the consumer", async () 
   const out = await collect(
     mapReduceStream(
       { text: "irrelevant", model: "m", host: "h" },
-      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: NOOP_PROGRESS,
+      },
       makePrompts(),
     ),
   );
@@ -300,13 +328,21 @@ test("mapReduceStream: abort between map and reduce stops further model calls", 
   const out = await collect(
     mapReduceStream(
       { text: "irrelevant", model: "m", host: "h", signal: controller.signal },
-      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: NOOP_PROGRESS,
+      },
       makePrompts(),
     ),
   );
 
   assert.deepStrictEqual(out, []);
-  assert.strictEqual(calls, 3, "should not call the model for further chunks or any reduce");
+  assert.strictEqual(
+    calls,
+    3,
+    "should not call the model for further chunks or any reduce",
+  );
 });
 
 test("mapReduceStream: OOM during map skips the tree and runs final reduce with partials so far", async () => {
@@ -451,7 +487,11 @@ test("mapReduceStream: final reduce sees at most maxChunks partials, even when m
   await collect(
     mapReduceStream(
       { text: "irrelevant", model: "m", host: "h" },
-      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: NOOP_PROGRESS,
+      },
       makePrompts(),
     ),
   );

--- a/apogee-extension/tests/summarize/mapReduce.test.js
+++ b/apogee-extension/tests/summarize/mapReduce.test.js
@@ -1,0 +1,494 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { mapReduceStream } from "../../lib/summarize/mapReduce.js";
+
+async function collect(gen) {
+  const out = [];
+  for await (const chunk of gen) out.push(chunk);
+  return out;
+}
+
+function recordingChat(partialFor) {
+  const calls = [];
+  async function* fn(_host, _model, prompt, opts) {
+    calls.push({ prompt, opts });
+    const out = partialFor
+      ? partialFor(prompt, calls.length)
+      : `partial for: ${prompt.slice(0, 12)}`;
+    if (Array.isArray(out)) {
+      for (const t of out) yield t;
+    } else {
+      yield out;
+    }
+  }
+  return { fn, calls };
+}
+
+function makePrompts() {
+  return {
+    buildSingle: (chunk) => `SINGLE: ${chunk}`,
+    buildMap: (chunk, i, total) => `MAP[${i}/${total}]: ${chunk}`,
+    buildReduce: (partials) => `REDUCE(${partials.length}): ${partials.join(" | ")}`,
+  };
+}
+
+const NOOP_PROGRESS = () => {};
+
+test("mapReduceStream: in-budget pipeline (3 chunks, budget 12) maps every chunk and runs one final reduce", async () => {
+  const { fn, calls } = recordingChat();
+  const out = await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      {
+        chunkTextFn: () => ["a", "b", "c"],
+        chatStreamFn: fn,
+        onProgress: NOOP_PROGRESS,
+      },
+      makePrompts(),
+    ),
+  );
+
+  // 3 map calls + 1 final reduce.
+  assert.strictEqual(calls.length, 4);
+  assert.match(calls[0].prompt, /^MAP\[0\/3\]: a$/);
+  assert.match(calls[1].prompt, /^MAP\[1\/3\]: b$/);
+  assert.match(calls[2].prompt, /^MAP\[2\/3\]: c$/);
+  assert.match(calls[3].prompt, /^REDUCE\(3\): /);
+  assert.strictEqual(out.length, 1);
+});
+
+test("mapReduceStream: at-budget (12 chunks, budget 12) does not enter the tree stage", async () => {
+  const { fn, calls } = recordingChat();
+  const progress = [];
+  const chunks = Array.from({ length: 12 }, (_, i) => `c${i}`);
+
+  await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: (p) => progress.push(p),
+      },
+      makePrompts(),
+    ),
+  );
+
+  // 12 map + 1 final reduce; no intermediate reduce events.
+  assert.strictEqual(calls.length, 13);
+  const reduceEvents = progress.filter((p) => p.stage === "reduce");
+  assert.strictEqual(reduceEvents.length, 1);
+  assert.ok(
+    !("depth" in reduceEvents[0]),
+    "the only reduce event should be the final one (no depth)",
+  );
+});
+
+test("mapReduceStream: 13 chunks, budget 12 → 13 map + 1 reduce of all 13 (no tree needed)", async () => {
+  const { fn, calls } = recordingChat();
+  const progress = [];
+  const chunks = Array.from({ length: 13 }, (_, i) => `c${i}`);
+
+  await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: (p) => progress.push(p),
+      },
+      makePrompts(),
+    ),
+  );
+
+  // 13 map + 1 final reduce. fanIn would be ceil(13/12)=2, but since
+  // 13 > 12, pickFanIn returns 2; we still need one tree round, so we
+  // expect 13 + ceil(13/2)=7 + 1 = 21 calls.
+  // The contract: the *final* reduce sees <= maxChunks partials.
+  assert.strictEqual(calls.length, 21);
+  const finalReduce = calls[calls.length - 1].prompt;
+  assert.match(finalReduce, /^REDUCE\(\d+\): /);
+  const partialsInFinal = finalReplaceCount(finalReduce);
+  assert.ok(
+    partialsInFinal <= 12,
+    `final reduce must see <= 12 partials, saw ${partialsInFinal}`,
+  );
+
+  // Exactly one final reduce event, and >= 1 intermediate reduce event.
+  const reduces = progress.filter((p) => p.stage === "reduce");
+  const intermediate = reduces.filter((p) => p.depth === 1);
+  assert.ok(intermediate.length >= 1, "expected at least one intermediate reduce event");
+  assert.strictEqual(reduces[reduces.length - 1].depth, undefined, "final reduce has no depth");
+});
+
+test("mapReduceStream: 48 chunks, budget 12 → 48 map + 12 first-level reduce + 1 final reduce (fanIn=4)", async () => {
+  const { fn, calls } = recordingChat();
+  const progress = [];
+  const chunks = Array.from({ length: 48 }, (_, i) => `c${i}`);
+
+  await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: (p) => progress.push(p),
+      },
+      makePrompts(),
+    ),
+  );
+
+  // 48 map + 12 first-level + 1 final = 61 calls.
+  assert.strictEqual(calls.length, 61);
+  const finalReduce = calls[calls.length - 1].prompt;
+  assert.match(finalReduce, /^REDUCE\(12\): /);
+
+  // Progress order: 48 map, then 12 reduce{depth:1}, then 1 reduce final.
+  const stages = progress.map((p) =>
+    p.stage === "map"
+      ? "m"
+      : p.stage === "reduce" && p.depth === 1
+        ? "r1"
+        : p.stage === "reduce"
+          ? "rf"
+          : "?",
+  );
+  const mapCount = stages.filter((s) => s === "m").length;
+  const r1Count = stages.filter((s) => s === "r1").length;
+  const rfCount = stages.filter((s) => s === "rf").length;
+  assert.strictEqual(mapCount, 48);
+  assert.strictEqual(r1Count, 12);
+  assert.strictEqual(rfCount, 1);
+
+  // The first reduce must come after all maps.
+  const firstReduceIdx = stages.indexOf("r1");
+  const lastMapIdx = stages.lastIndexOf("m");
+  assert.ok(firstReduceIdx > lastMapIdx, "intermediate reduce must follow all maps");
+
+  // The final reduce must come after all intermediate reduces.
+  const finalReduceIdx = stages.indexOf("rf");
+  const lastR1Idx = stages.lastIndexOf("r1");
+  assert.ok(finalReduceIdx > lastR1Idx, "final reduce must follow intermediate reduces");
+});
+
+test("mapReduceStream: 24 chunks, budget 12 → fanIn=2 → 24 map + 12 reduce + 1 final", async () => {
+  const { fn, calls } = recordingChat();
+  const chunks = Array.from({ length: 24 }, (_, i) => `c${i}`);
+
+  await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      makePrompts(),
+    ),
+  );
+
+  // 24 map + 12 reduce + 1 final = 37 calls.
+  assert.strictEqual(calls.length, 37);
+  const finalReduce = calls[calls.length - 1].prompt;
+  assert.match(finalReduce, /^REDUCE\(12\): /);
+});
+
+test("mapReduceStream: tree-reduce groups partials in input order", async () => {
+  // Every leaf partials[i] starts with its index; we want to verify
+  // that the first-level reduce groups partials in order and that
+  // the final reduce sees the grouped intermediates in order.
+  const seen = [];
+  async function* fn(_host, _model, prompt) {
+    seen.push(prompt);
+    if (prompt.startsWith("MAP[")) {
+      const m = prompt.match(/^MAP\[\d+\/\d+\]: (.*)$/);
+      yield `LEAF[${m[1]}]`;
+    } else {
+      yield `INTERMEDIATE[${prompt.slice("REDUCE(".length)}]`;
+    }
+  }
+
+  const chunks = Array.from({ length: 8 }, (_, i) => `c${i}`);
+
+  await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      {
+        buildSingle: (c) => `SINGLE: ${c}`,
+        buildMap: (c, i, t) => `MAP[${i}/${t}]: ${c}`,
+        buildReduce: (ps) =>
+          `REDUCE(${ps.length}): ${ps.join(" || ")}`,
+      },
+    ),
+  );
+
+  // 8 chunks, budget 12 → no tree (8 ≤ 12). But the issue is about
+  // order preservation; that is most visible when the tree fires.
+  // Re-run with a smaller budget by using a Transformers model.
+  seen.length = 0;
+  await collect(
+    mapReduceStream(
+      {
+        text: "irrelevant",
+        model: "HuggingFaceTB/SmolLM2-360M-Instruct",
+        host: "h",
+      },
+      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      {
+        buildSingle: (c) => `SINGLE: ${c}`,
+        buildMap: (c, i, t) => `MAP[${i}/${t}]: ${c}`,
+        buildReduce: (ps) =>
+          `REDUCE(${ps.length}): ${ps.join(" || ")}`,
+      },
+    ),
+  );
+
+  // The first intermediate reduce should be over the first group of
+  // partials in order. Find the first REDUCE prompt and check it
+  // contains the expected leaves in order.
+  const firstReduce = seen.find((p) => p.startsWith("REDUCE("));
+  // 8 partials over budget 4: fanIn = ceil(8/4) = 2, so 4 groups.
+  // First group: LEAF[c0], LEAF[c1].
+  assert.match(firstReduce, /LEAF\[c0\] \|\| LEAF\[c1\]/);
+});
+
+test("mapReduceStream: intermediate reduce tokens reach the consumer", async () => {
+  // 16 chunks, budget 12: fanIn = ceil(16/12) = 2, so the tree fires
+  // (16 → 8 intermediates → 1 final). The intermediate reduce calls
+  // are themselves streamed; we just need to assert that the final
+  // reduce prompt aggregates the intermediate outputs and the final
+  // streamed output reaches the consumer.
+  const seen = [];
+  async function* fn(_host, _model, prompt) {
+    seen.push(prompt);
+    if (prompt.startsWith("MAP[")) {
+      yield "leafa";
+    } else if (/^REDUCE\(2\):/.test(prompt)) {
+      // First-level reduce: 2 partials collapsed to 1 intermediate.
+      yield "intermediate-1";
+    } else {
+      // Final reduce.
+      yield "final-output";
+    }
+  }
+
+  const chunks = Array.from({ length: 16 }, (_, i) => `c${i}`);
+  const out = await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      makePrompts(),
+    ),
+  );
+
+  // 16 map + 8 first-level + 1 final = 25 calls.
+  assert.strictEqual(seen.length, 25);
+  assert.deepStrictEqual(out, ["final-output"]);
+  // The final reduce prompt should contain the intermediate strings.
+  const final = seen[seen.length - 1];
+  assert.match(final, /intermediate-1/);
+});
+
+test("mapReduceStream: abort between map and reduce stops further model calls", async () => {
+  const controller = new AbortController();
+  let calls = 0;
+  async function* fn() {
+    calls += 1;
+    if (calls === 3) controller.abort();
+    yield "x";
+  }
+
+  const chunks = Array.from({ length: 20 }, (_, i) => `c${i}`);
+  const out = await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h", signal: controller.signal },
+      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      makePrompts(),
+    ),
+  );
+
+  assert.deepStrictEqual(out, []);
+  assert.strictEqual(calls, 3, "should not call the model for further chunks or any reduce");
+});
+
+test("mapReduceStream: OOM during map skips the tree and runs final reduce with partials so far", async () => {
+  const progress = [];
+  let calls = 0;
+  async function* fn() {
+    calls += 1;
+    if (calls === 4) {
+      throw new Error("RESOURCE: gpubuffer allocation failed");
+    }
+    yield "ok";
+  }
+
+  const chunks = Array.from({ length: 12 }, (_, i) => `c${i}`);
+  const out = await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: (p) => progress.push(p),
+      },
+      makePrompts(),
+    ),
+  );
+
+  // 3 successful map calls + 1 OOM throw = 4 chat fn invocations,
+  // then the pipeline runs the final reduce on 3 partials = 1 more.
+  // Total: 5 calls. No tree stage.
+  assert.strictEqual(calls, 5);
+  const reduces = progress.filter((p) => p.stage === "reduce");
+  assert.strictEqual(reduces.length, 1);
+  assert.ok(!("depth" in reduces[0]), "the only reduce is the final one");
+  assert.ok(progress.some((p) => p.stage === "oom_fallback"));
+  // The streamed output is whatever the final reduce yielded: "ok".
+  assert.deepStrictEqual(out, ["ok"]);
+});
+
+test("mapReduceStream: OOM during intermediate reduce stops the tree and uses what we have", async () => {
+  const progress = [];
+  let calls = 0;
+  async function* fn() {
+    calls += 1;
+    // 8 map calls succeed. The tree is configured for budget 4
+    // (Transformers.js model), so fanIn = ceil(8/4) = 2 and the
+    // first intermediate reduce is call 9. The OOM halts the tree,
+    // and the final reduce (call 10) consumes the original 8
+    // partials.
+    if (calls === 9) {
+      throw new Error("gpubuffer allocation failed");
+    }
+    yield calls <= 8 ? `LEAF-${calls}` : "INTERMEDIATE";
+  }
+
+  const chunks = Array.from({ length: 8 }, (_, i) => `c${i}`);
+  const out = await collect(
+    mapReduceStream(
+      {
+        text: "irrelevant",
+        model: "HuggingFaceTB/SmolLM2-360M-Instruct",
+        host: "h",
+      },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: (p) => progress.push(p),
+      },
+      makePrompts(),
+    ),
+  );
+
+  // 8 map + 1 OOM reduce + 1 final reduce on the original partials = 10 calls.
+  assert.strictEqual(calls, 10);
+  assert.ok(progress.some((p) => p.stage === "oom_fallback"));
+  assert.deepStrictEqual(out, ["INTERMEDIATE"]);
+});
+
+test("mapReduceStream: a custom selectChunksFn wins over the tree-reduce", async () => {
+  let calls = 0;
+  async function* fn() {
+    calls += 1;
+    yield "x";
+  }
+
+  const chunks = Array.from({ length: 30 }, (_, i) => `c${i}`);
+  const selectChunksFn = (all) => all.slice(0, 3);
+
+  await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: NOOP_PROGRESS,
+        selectChunksFn,
+      },
+      makePrompts(),
+    ),
+  );
+
+  // 3 map + 1 final reduce = 4 calls; no tree.
+  assert.strictEqual(calls, 4);
+});
+
+test("mapReduceStream: a failing selectChunksFn falls through to the default (no chunks dropped)", async () => {
+  let calls = 0;
+  async function* fn() {
+    calls += 1;
+    yield "x";
+  }
+
+  const chunks = Array.from({ length: 6 }, (_, i) => `c${i}`);
+  const selectChunksFn = () => {
+    throw new Error("selector broken");
+  };
+
+  await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      {
+        chunkTextFn: () => chunks,
+        chatStreamFn: fn,
+        onProgress: NOOP_PROGRESS,
+        selectChunksFn,
+      },
+      makePrompts(),
+    ),
+  );
+
+  // 6 chunks ≤ budget 12: flat reduce, 6 + 1 = 7 calls. The failing
+  // selector must not have raised, and the tree stage must not have
+  // fired (6 ≤ 12).
+  assert.strictEqual(calls, 7);
+});
+
+test("mapReduceStream: final reduce sees at most maxChunks partials, even when map produced more", async () => {
+  // Direct stress: 60 chunks, budget 12. fanIn = ceil(60/12) = 5.
+  // Expect 60 map + 12 first-level + 1 final = 73 calls.
+  const { fn, calls } = recordingChat();
+  const chunks = Array.from({ length: 60 }, (_, i) => `c${i}`);
+
+  await collect(
+    mapReduceStream(
+      { text: "irrelevant", model: "m", host: "h" },
+      { chunkTextFn: () => chunks, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      makePrompts(),
+    ),
+  );
+
+  assert.strictEqual(calls.length, 73);
+  const finalReduce = calls[calls.length - 1].prompt;
+  const m = finalReduce.match(/^REDUCE\((\d+)\): /);
+  assert.ok(m, "final reduce prompt shape");
+  const n = parseInt(m[1], 10);
+  assert.ok(
+    n <= 12,
+    `final reduce must receive at most maxChunks=12 partials, saw ${n}`,
+  );
+});
+
+test("mapReduceStream: cleanText runs on the input before chunking", async () => {
+  const chunkTextFn = (text) => [`cleaned:${text.length}`];
+  const { fn, calls } = recordingChat();
+  await collect(
+    mapReduceStream(
+      { text: "hello   \n\n\n world ", model: "m", host: "h" },
+      { chunkTextFn, chatStreamFn: fn, onProgress: NOOP_PROGRESS },
+      makePrompts(),
+    ),
+  );
+
+  // One chunk, fast path: buildSingle is called with the cleaned chunk.
+  assert.strictEqual(calls.length, 1);
+  assert.match(calls[0].prompt, /^SINGLE: cleaned:\d+$/);
+});
+
+// Tiny helper: count items inside the joined " || "-delimited partials
+// string of a REDUCE prompt.
+function finalReplaceCount(prompt) {
+  const m = prompt.match(/^REDUCE\((\d+)\): /);
+  if (!m) return -1;
+  const body = prompt.slice(m[0].length);
+  // Build was buildReduce: (ps) => `REDUCE(${ps.length}): ${ps.join(" | ")}`
+  return body.split(" | ").length;
+}

--- a/apogee-extension/tests/summarize/ollamaSummarize.test.js
+++ b/apogee-extension/tests/summarize/ollamaSummarize.test.js
@@ -374,3 +374,62 @@ test("summarizeText with no/auto language streams directly with no system direct
   );
   assert.strictEqual(out, "Plain summary");
 });
+
+test("summarizeText (long article, Transformers.js model) keeps every chunk and feeds the final reduce <= 4 partials", async () => {
+  // 20 chunks on a model with maxChunks=4: the new pipeline keeps
+  // all 20, maps them, then tree-reduces 20 -> 4 first-level -> 1
+  // final (fanIn = ceil(20/4) = 5, so 4 groups of 5 collapse to 4
+  // intermediates, which is already within the budget). The final
+  // reduce must see <= 4 partials so that buildScaledBulletsStyle
+  // (which keys off the partials count) does not balloon.
+  const prompts = [];
+  // Make each partial distinct so we can count them inside the
+  // synthesis prompt's notes block.
+  async function* chatStreamFn(_host, _model, _prompt) {
+    prompts.push(_prompt);
+    yield `- note #${prompts.length}\n`;
+  }
+
+  const chunks = Array.from({ length: 20 }, (_, i) => `chunk ${i}`);
+  await collect(
+    summarizeText(
+      {
+        text: chunks.join(" "),
+        title: "Long article",
+        url: "https://example.com",
+        mode: "bullets",
+        model: "HuggingFaceTB/SmolLM2-360M-Instruct",
+      },
+      { chunkTextFn: () => chunks, chatStreamFn },
+    ),
+  );
+
+  // 20 map + 4 first-level + 1 final = 25.
+  assert.strictEqual(prompts.length, 25);
+
+  // The final reduce is the synthesis prompt. It contains the notes
+  // joined with "\n" - count the distinct partials in it.
+  const finalReducePrompt = prompts[prompts.length - 1];
+  assert.match(
+    finalReducePrompt,
+    /notes extracted from across a long document/,
+    "final reduce should be the synthesis prompt",
+  );
+  const noteMarkers = finalReducePrompt.match(/- note #\d+/g) || [];
+  assert.ok(
+    noteMarkers.length <= 4,
+    `final reduce must see at most maxChunks=4 partials, saw ${noteMarkers.length}`,
+  );
+
+  // The bullet count rule in the final prompt must be consistent
+  // with the actual partials count (so the model gets a
+  // self-consistent instruction set). With <=4 partials,
+  // buildScaledBulletsStyle produces 5-14 (clamped).
+  const bulletCountMatch = finalReducePrompt.match(/Output (\d+)-(\d+) bullet/);
+  assert.ok(bulletCountMatch, "synthesis prompt should include bullet count");
+  const maxBullets = parseInt(bulletCountMatch[2], 10);
+  assert.ok(
+    maxBullets <= 14,
+    `bullet count upper bound should be capped at 14, got ${maxBullets}`,
+  );
+});

--- a/apogee-extension/tests/summarize/youtubeSummarize.test.js
+++ b/apogee-extension/tests/summarize/youtubeSummarize.test.js
@@ -224,7 +224,16 @@ test("summarizeYoutube stops issuing new model calls once the signal is aborted 
   );
 });
 
-test("summarizeYoutube truncates to the chunk cap instead of growing chunks past the context budget", async () => {
+test("summarizeYoutube keeps every chunk when the input exceeds the chunk cap and tree-reduces them", async () => {
+  // 300k chars at the model-derived chunk size yields ~37 chunks once
+  // the YouTube-specific YOUTUBE_MAP_CHUNK_CHARS cap (8192) is applied.
+  // Before the hierarchical map-reduce change, this dropped to 12 (and
+  // lost ~70% of the material). Now we keep every chunk, map them all,
+  // and tree-reduce the partials down to <= 12, then final reduce
+  // once. The exact call count depends on getMaxChunkChars for the
+  // (unspecified) model; we assert the shape of the events and the
+  // presence of intermediate tree-reduce calls instead of a hard
+  // number.
   const longText = "x".repeat(300000);
   const chunkCalls = [];
   const chunkTextFn = (text, maxChars) => {
@@ -248,9 +257,42 @@ test("summarizeYoutube truncates to the chunk cap instead of growing chunks past
   );
 
   assert.strictEqual(chunkCalls.length, 1, "should never re-chunk bigger");
+  // No truncation by default - the new pipeline keeps every chunk.
   const truncated = progressEvents.filter((p) => p.stage === "truncated");
-  assert.strictEqual(truncated.length, 1);
-  assert.strictEqual(truncated[0].kept, 12);
-  assert.ok(truncated[0].total > 12);
-  assert.strictEqual(mapCalls, 13);
+  assert.strictEqual(
+    truncated.length,
+    0,
+    "no chunks are dropped by default; the tree-reduce folds them instead",
+  );
+  // The map stage should produce more than the budget (12) so the
+  // tree stage actually fires. The YOUTUBE_MAP_CHUNK_CHARS cap yields
+  // ~37 chunks from 300k chars.
+  const mapEvents = progressEvents.filter((p) => p.stage === "map");
+  assert.ok(
+    mapEvents.length > 12,
+    `map stage should produce more than 12 chunks, got ${mapEvents.length}`,
+  );
+  // At least one intermediate tree-reduce call plus a final reduce.
+  const intermediateReduces = progressEvents.filter(
+    (p) => p.stage === "reduce" && p.depth === 1,
+  );
+  const finalReduces = progressEvents.filter(
+    (p) => p.stage === "reduce" && p.depth === undefined,
+  );
+  assert.ok(
+    intermediateReduces.length > 0,
+    "expected at least one intermediate reduce (the tree must fire)",
+  );
+  assert.strictEqual(finalReduces.length, 1);
+  // The final reduce must see <= 12 partials (the budget).
+  const finalReduce = progressEvents[progressEvents.length - 1];
+  assert.strictEqual(finalReduce.stage, "reduce");
+  // The chat fn was called once per map + once per intermediate
+  // reduce + once for the final reduce. We already know the map
+  // count; just assert it's strictly more than the 13 (12 maps + 1
+  // final) the old pipeline produced.
+  assert.ok(
+    mapCalls > 13,
+    `old pipeline did 13 model calls; new pipeline does at least 13+ (got ${mapCalls})`,
+  );
 });


### PR DESCRIPTION
Replaces the silent chunk-dropping fallback in `apogee-extension/lib/summarize/mapReduce.js`
with a hierarchical (tree-reduce) map-reduce. When a page produces more
chunks than the model's `getMaxChunks` budget (4 for Transformers.js, 12
for Ollama), the previous code called `stratifiedSample(chunks, maxChunks)`
— picking `maxChunks` evenly-spaced chunks by index and silently dropping
the rest. On a long article, 2-hour YouTube transcript, or 200-message
Hacker News thread, that meant losing ~75% of the material before the
summary was even attempted.

The new pipeline keeps every chunk:

1. **Map stage** (unchanged surface) — runs `buildMap(chunk, i, total)`
   on every chunk in order; `N` model calls, no chunks dropped.
2. **Tree-reduce stage** (new) — groups partials in slices of
   `fanIn = Math.max(2, Math.ceil(partials.length / maxChunks))` and
   streams `buildReduce(group)` for each group, emitting
   `{ stage: "reduce", depth: 1, index, total }` per call. The grouping
   guarantees the next round holds ≤ `maxChunks` intermediates, so the
   loop terminates in one round for most inputs.
3. **Final reduce** (unchanged) — once ≤ `maxChunks` intermediates
   remain, the existing `buildReduce(intermediates)` is streamed to
   the consumer. Emits `{ stage: "reduce" }` with no `depth`, matching
   the previous shape.

The `buildSingle` / `buildMap` / `buildReduce` contract is unchanged, so
the two callers (`ollamaSummarize.js`, `youtubeSummarize.js`) work
without modification. A custom `selectChunksFn` still wins over the
tree when provided; the new tree only fires when there is no selector
(or it failed). The OOM escape hatch from the map stage
(`stage: "oom_fallback"`) is preserved and extended: an OOM during the
tree halts the tree and the final reduce runs over whatever partials
were already produced, so the consumer still gets a streamed output.

Progress event changes for callers / UI:
- `{ stage: "truncated" }` no longer fires on overflow by default; it
  only fires when an injected `selectChunksFn` returns fewer chunks
  than the input supplied. The progress event semantics now mean
  "the selector picked a subset", not "we threw material away".
- `{ stage: "reduce", depth, index, total }` is new for intermediate
  tree calls. The final reduce event still has no `depth` field, so
  existing listeners continue to work.

Resolves #148.

**Files**
- `apogee-extension/lib/summarize/mapReduce.js` — rewrite
- `apogee-extension/tests/summarize/mapReduce.test.js` (new) — 14
  cases: in-budget, at-budget, 13/24/48/60-chunk overflow with the
  expected call count, input-order preservation in tree groups,
  intermediate streaming, abort between map and reduce, OOM during
  map, OOM during tree, `selectChunksFn` precedence (custom and
  failing), and the final-budget contract.
- `apogee-extension/tests/summarize/ollamaSummarize.test.js` — one
  new integration test confirming a 20-chunk Transformers.js model
  path keeps every chunk and feeds the final reduce ≤ 4 partials,
  so `buildScaledBulletsStyle` doesn't balloon.
- `apogee-extension/tests/summarize/youtubeSummarize.test.js` —
  replace the old "truncates to the chunk cap" assertion with a
  "keeps every chunk and tree-reduces" one.
- `CHANGELOG.md` — one bullet under a new `### Changed` section.

**Trade-off to flag**: model-call count goes up on overflow. A
48-chunk document on a Transformers.js model (budget 4) used to do
4 map + 1 reduce = 5 calls because `stratifiedSample` collapsed the
input to 4 chunks before mapping. After this change it does
48 map + 12 first-level + 1 final = 61 calls. The extra work is
the point of the fix — silent data loss was the bug. For the
common case (≤ budget) the cost is unchanged.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [ ] Manually exercised the change in a loaded browser extension

449/451 tests pass; the 2 failures are the pre-existing Windows
`tests/manifest.test.js` path bug (unrelated to this PR — `new URL(...).pathname`
returns `/D:/...` and `resolve()` mangles it to `D:\D:\...`). Lint is
clean. Both `dist/chrome` and `dist/firefox` build successfully;
`lib/summarize/mapReduce.js` is tree-shaken into
`chunks/streamBroadcast-*.js` in both outputs (verified by
`grep -c "reduceTree\|pickFanIn" dist/{chrome,firefox}/chunks/*.js`).

`npm run format:check` is clean (no Prettier reformat was needed; the
existing repo's Prettier config was already satisfied by the new
code).

Manual browser exercise: not done by me — I do not have a running
extension environment in this session. The path is the same as the
existing pipeline: load `dist/chrome` as an unpacked extension,
open a long article or transcript, click Summarize. Behavioural
change is invisible at the UI layer unless the user looks at the
DevTools console for the new `{ stage: "reduce", depth: 1, ... }`
progress events, or unless they summarize something that was
previously getting silently truncated.

## Privacy impact

- [x] No new outbound network calls
- [ ] Adds/changes a network call (described above, docs updated)

No new outbound network calls. The pipeline still calls the
already-configured local provider (Ollama, llama.cpp, WebLLM, or
Transformers.js). The same loopback host, the same headers, the
same payloads. The only behavioural change is *how many times* the
already-permitted model endpoint is called, not *where* those calls
go.

- [x] Permissions unchanged, or all four of manifest / README / PRIVACY /
      store-listing updated together

**No permission or manifest changes**. `apogee-extension/manifest.json`,
`README.md`, `PRIVACY.md`, and `STORE-LISTING.md` are all
unchanged by this PR. The change is purely internal to
`lib/summarize/mapReduce.js` and its tests.