### PR TITLE
fix(build): fail closed when dev mock guard cannot be stripped

### DIFF
--- a/apogee-extension/vite.config.js
+++ b/apogee-extension/vite.config.js
@@ -148,7 +148,8 @@ export default defineConfig(() => {
           if (this._isWatch) return null;
           if (!id.endsWith("ui/app.js")) return null;
 
-          const mockGuardPattern = /if \(\s*typeof chrome === "undefined"[\s\S]*?await import\("\.\/mock\.js"\);\s*\}\n?/;
+          const mockGuardPattern =
+            /if \(\s*typeof chrome === "undefined"[\s\S]*?await import\("\.\/mock\.js"\);\s*\}\n?/;
           const match = code.match(mockGuardPattern);
           if (!match) {
             throw new Error(

--- a/apogee-extension/vite.config.js
+++ b/apogee-extension/vite.config.js
@@ -147,18 +147,16 @@ export default defineConfig(() => {
         transform(code, id) {
           if (this._isWatch) return null;
           if (!id.endsWith("ui/app.js")) return null;
-          const stripped = code.replace(
-            /if \(\s*typeof chrome === "undefined"[\s\S]*?await import\("\.\/mock\.js"\);\s*\}\n?/,
-            "",
-          );
-          if (stripped === code) {
-            this.warn(
-              "strip-dev-mock: mock.js import guard not found in app.js; " +
-                "the strip pattern may be stale (mock chunk may still ship).",
+
+          const mockGuardPattern = /if \(\s*typeof chrome === "undefined"[\s\S]*?await import\("\.\/mock\.js"\);\s*\}\n?/;
+          const match = code.match(mockGuardPattern);
+          if (!match) {
+            throw new Error(
+              "strip-dev-mock: mock.js import guard not found in app.js; refusing to continue production build.",
             );
-            return null;
           }
-          return { code: stripped, map: null };
+
+          return { code: code.replace(mockGuardPattern, ""), map: null };
         },
       },
 


### PR DESCRIPTION
## Fixes #192

### Summary

Make the `strip-dev-mock` Vite plugin fail closed when the development mock import guard cannot be found.

### Changes

* Throw a build error when the expected `mock.js` import guard is missing.
* Prevent production builds from silently shipping the development mock.
* Preserve the existing watch/dev behavior.
* Keep the change limited to `apogee-extension/vite.config.js`.

### Why

Previously, a failed regex match only generated a warning and allowed the production build to continue. This could result in `mock.js` being included in the production bundle.

With this fix, the build stops immediately if the guard cannot be stripped.

Fixes #192
