### PR TITLE
fix(deps): remove redundant shell-quote override (#190)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,14 @@ This guide provides a comprehensive overview of Apogee codebase architecture, re
    npm run install:extension
    ```
 
+### Dependency overrides
+
+`apogee-extension/package.json` pins three transitive dependencies above the ranges their parents declare. Each pin exists because of a real advisory, so don't loosen one without checking `npm audit` first:
+
+- `adm-zip@^0.6.0` (`onnxruntime-node` asks for `^0.5.16`): GHSA-xcpc-8h2w-3j85, where a crafted ZIP triggers a multi-gigabyte allocation. Fixed in 0.6.0.
+- `sharp@^0.35.0` (`@huggingface/transformers` asks for `^0.34.5`): GHSA-f88m-g3jw-g9cj, libvips flaws up to High severity. Fixed from 0.35.0.
+- `brace-expansion@^5.0.9` (old `minimatch@3` asks for `^1.1.7`): GHSA-rgw5-rvv9-x895 and earlier brace-expansion DoS advisories. Forces the patched 5.x line even where old minimatch asks for 1.x.
+
 ## Development and Build Commands
 
 Run `install:extension`, `build`, `test`, `lint`, `format`, `dev`, and `package` from the repository root or inside the `apogee-extension` directory. The remaining scripts (`format:check`, `build:chrome`, `build:firefox`, `start:firefox`, `start:chrome`, `lint:webext`) exist only inside `apogee-extension/`.

--- a/apogee-extension/package.json
+++ b/apogee-extension/package.json
@@ -40,7 +40,6 @@
   },
   "overrides": {
     "adm-zip": "^0.6.0",
-    "shell-quote": "^1.9.0",
     "sharp": "^0.35.0",
     "brace-expansion": "^5.0.9"
   }


### PR DESCRIPTION
## Fixes #190

### Summary

Clean up the stale dependency overrides identified in Issue #190, and document why the remaining pins must stay.

### Changes

* Removed the redundant `shell-quote` override from `apogee-extension/package.json` (the only consumer pins the same version exactly, so the override was a no-op).
* Documented the three remaining overrides in `DEVELOPMENT.md` with the advisory behind each (`adm-zip` GHSA-xcpc-8h2w-3j85, `sharp` GHSA-f88m-g3jw-g9cj, `brace-expansion` GHSA-rgw5-rvv9-x895) so a future cleanup doesn't loosen a live security pin.
* Kept all other dependency overrides unchanged.

### Why

The `shell-quote` override was not providing a meaningful version constraint and was identified in Issue #190 as safe to remove unless a regression pin was required.

Removing it avoids maintaining an unnecessary override, while the new docs make sure the intentional pins survive the next cleanup pass.

### Testing

* Verified the branch is rebased onto current `main`.
* Verified `apogee-extension/package.json` and `DEVELOPMENT.md` are the only files changed.
* Prettier check passes.

Fixes #190
