### PR TITLE
fix(deps): remove vulnerable image-size override (#189)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,10 @@ Please **do** report a mismatch between what the docs promise and what the code 
 - Reports against your own Ollama instance's configuration, which is outside what this extension controls
 - Automated scanner output with no working proof of concept
 
+## Accepted risks
+
+- **`image-size` HIGH advisories in dev tooling (`GHSA-w3rx-r6r6-pgpr`, `GHSA-5p2g-fcmc-qvqq`).** The vulnerable ICNS/JXL/HEIF parsers reach us only through `web-ext` → `addons-linter`, which pins `image-size@2.0.2` exactly, and no fixed upstream release exists. Exploiting it needs a malicious image inside this repo, which already means commit access, and only affects the machine running the linter; the shipped extension never bundles it (`npm audit --omit=dev` is clean). Accepted until upstream ships a fix; re-check on every dependency bump.
+
 ## Supported versions
 
 Only the latest released version gets fixes. Apogee ships through the Chrome Web Store and Firefox Add-ons, which auto-update, so "upgrade to the current version" is the remedy for anything reported against an older one.

--- a/apogee-extension/package.json
+++ b/apogee-extension/package.json
@@ -42,7 +42,6 @@
     "adm-zip": "^0.6.0",
     "shell-quote": "^1.9.0",
     "sharp": "^0.35.0",
-    "brace-expansion": "^5.0.9",
-    "image-size": "2.0.2"
+    "brace-expansion": "^5.0.9"
   }
 }


### PR DESCRIPTION
## Related to #189

### Summary

Remove the `image-size` override that pins the extension's development tooling to the vulnerable `2.0.2` version.

### Changes

* Removed the `image-size: 2.0.2` override from `apogee-extension/package.json`.
* Kept all other dependency overrides unchanged.
* Limited the change to the dependency override configuration.

### Why

Issue #189 reports multiple HIGH-severity `image-size` vulnerabilities affecting the development-only dependency chain through `web-ext` and `addons-linter`.

The override was explicitly forcing `image-size` to `2.0.2`, preventing the dependency tree from resolving a newer version.

Removing the override eliminates the stale forced pin and allows the dependency resolver to use the version required by the current tooling chain.

### Scope note

This removes our own force-pin, but `npm audit` still reports the same 3 HIGH `image-size` findings afterwards: they come from `addons-linter`'s own version range and clear only with the breaking `addons-linter@2.21.0` upgrade. Kept as Related (not Fixes) so #189 stays open until then.

### Testing

* Verified the branch is one commit ahead of `main`.
* Verified only `apogee-extension/package.json` is modified.
* No unrelated files were changed.

Related to #189
