### PR TITLE
fix: Add delete button for past summaries

### DIFF
--- a/apogee-extension/ui/app.css
+++ b/apogee-extension/ui/app.css
@@ -998,7 +998,7 @@ body {
 }
 
 .past-summary-card.expanded .past-summary-title {
-  padding-right: 60px;
+  padding-right: 92px;
   font-size: 13px;
   line-height: 1.35;
   color: var(--text-main);
@@ -1099,7 +1099,7 @@ body {
   .past-summary-text
   > .past-summary-preview:first-child
   > :first-child {
-  padding-right: 60px;
+  padding-right: 92px;
 }
 
 .past-summary-card.expanded .past-summary-actions {
@@ -1108,7 +1108,8 @@ body {
   right: 14px;
 }
 
-.past-summary-card .copy-btn {
+.past-summary-card .copy-btn,
+.past-summary-card .delete-btn {
   flex-shrink: 0;
 }
 
@@ -1157,7 +1158,8 @@ body {
   gap: 8px;
 }
 
-.copy-btn {
+.copy-btn,
+.delete-btn {
   width: 26px;
   height: 26px;
   border: 1px solid var(--btn-border);
@@ -1175,7 +1177,14 @@ body {
   border-color: var(--btn-hover-border);
 }
 
-.copy-btn .ico svg {
+.delete-btn:hover {
+  background: rgba(239, 68, 68, 0.16);
+  border-color: rgba(239, 68, 68, 0.55);
+  color: #ef4444;
+}
+
+.copy-btn .ico svg,
+.delete-btn .ico svg {
   width: 15px;
   height: 15px;
 }

--- a/apogee-extension/ui/app.js
+++ b/apogee-extension/ui/app.js
@@ -1081,10 +1081,11 @@ async function loadPastSummaries() {
       else preview.textContent = firstLineOf(text);
     };
     card.addEventListener("click", (e) => {
-      if (e.target.closest("a")) return;
+      if (e.target.closest("a, button")) return;
       toggleExpanded();
     });
     card.addEventListener("keydown", (e) => {
+      if (e.target.closest("button")) return;
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
         toggleExpanded();
@@ -1105,28 +1106,36 @@ async function loadPastSummaries() {
     chevron.className = "past-summary-chevron";
     chevron.setAttribute("aria-hidden", "true");
     chevron.innerHTML = icon("chevron");
-    
+
+    // The actions bar lives outside the collapsible preview, so this one
+    // delete button serves both the collapsed (off) and expanded (open)
+    // card states: inline in the row when collapsed, pinned top-right via
+    // CSS when the card is expanded.
     const deleteBtn = document.createElement("button");
     deleteBtn.type = "button";
     deleteBtn.className = "delete-btn";
     deleteBtn.setAttribute("aria-label", "Delete this summary");
+    deleteBtn.title = "Delete this summary";
     deleteBtn.innerHTML = icon("trash");
-
     deleteBtn.addEventListener("click", async (e) => {
       e.stopPropagation();
-
-      await chrome.storage.local.remove([entry.s, entry.p]);
-
-      const { cacheOrder = [] } = 
-       await chrome.storage.local.get("cacheOrder");
-
-       const updatedOrder = cacheOrder.filter((e) => e && e.s !== entry.s);
-       
-       await chrome.storage.local.set({ cacheOrder: updatedOrder });
-
-       await loadPastSummaries();
-      
+      try {
+        const removeKeys = [entry.s, entry.p].filter(Boolean);
+        if (removeKeys.length > 0) {
+          await chrome.storage.local.remove(removeKeys);
+        }
+        const { cacheOrder = [] } =
+          await chrome.storage.local.get("cacheOrder");
+        const updatedOrder = cacheOrder.filter(
+          (item) => item && item.s !== entry.s,
+        );
+        await chrome.storage.local.set({ cacheOrder: updatedOrder });
+        await loadPastSummaries();
+      } catch (err) {
+        console.error("Delete past summary error:", err);
+      }
     });
+
     const actions = document.createElement("div");
     actions.className = "past-summary-actions";
     actions.append(copyBtn, deleteBtn, chevron);

--- a/apogee-extension/ui/app.js
+++ b/apogee-extension/ui/app.js
@@ -1105,10 +1105,31 @@ async function loadPastSummaries() {
     chevron.className = "past-summary-chevron";
     chevron.setAttribute("aria-hidden", "true");
     chevron.innerHTML = icon("chevron");
+    
+    const deleteBtn = document.createElement("button");
+    deleteBtn.type = "button";
+    deleteBtn.className = "delete-btn";
+    deleteBtn.setAttribute("aria-label", "Delete this summary");
+    deleteBtn.innerHTML = icon("trash");
 
+    deleteBtn.addEventListener("click", async (e) => {
+      e.stopPropagation();
+
+      await chrome.storage.local.remove([entry.s, entry.p]);
+
+      const { cacheOrder = [] } = 
+       await chrome.storage.local.get("cacheOrder");
+
+       const updatedOrder = cacheOrder.filter((e) => e && e.s !== entry.s);
+       
+       await chrome.storage.local.set({ cacheOrder: updatedOrder });
+
+       await loadPastSummaries();
+      
+    });
     const actions = document.createElement("div");
     actions.className = "past-summary-actions";
-    actions.append(copyBtn, chevron);
+    actions.append(copyBtn, deleteBtn, chevron);
     card.appendChild(actions);
 
     pastSummariesList.appendChild(card);


### PR DESCRIPTION
## Summary
Added a delete button component to each entry in the past summaries list in `apogee-extension/ui/app.js`. Removed the `summary` and `prompts` keys from storage on delete. Removed the entry from `cacheOrder` on delete.

## Test plan

<!-- How did you verify this? Check the boxes you actually ran. -->

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [ ] Manually exercised the change in a loaded browser extension

## Privacy impact

<!-- Does this add, remove, or change any outbound network request or permission? -->

- [x] No new outbound network calls
- [ ] Adds/changes a network call (described above, docs updated)

<!-- Permissions and network behaviour are described in four places that must
     agree: apogee-extension/manifest.json, README.md (Privacy & Permissions),
     PRIVACY.md, and STORE-LISTING.md (permission justifications). A claim in
     one and not the others is what store reviewers catch. -->

- [x] Permissions unchanged, or all four of manifest / README / PRIVACY /
      store-listing updated together
