### PR TITLE
fix: close undisclosed github api egress and sensitive audit logging

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -839,12 +839,17 @@ async function runBackgroundSummarize(
     await persistContent(tab.url, pageData);
   }
 
-  recordPageAccessEvent({
-    title: pageData.title,
-    url: pageData.url,
-    contentLength: (pageData.content || "").length,
-    type: pageData.type,
-  }).catch(() => {});
+  // The audit log lives in on-disk storage alongside the cache, so it
+  // follows the same persistence decision: sensitive pages and "Don't save"
+  // sessions (persist === false) leave no title+URL trace behind.
+  if (persist) {
+    recordPageAccessEvent({
+      title: pageData.title,
+      url: pageData.url,
+      contentLength: (pageData.content || "").length,
+      type: pageData.type,
+    }).catch(() => {});
+  }
 
   let content = pageData.content;
   if (pageData.isPdf) {

--- a/apogee-extension/content/extractors/github.js
+++ b/apogee-extension/content/extractors/github.js
@@ -50,20 +50,31 @@ function ghConversation() {
   return out;
 }
 
-async function ghFetchDiff(owner, repo, number) {
-  const api = `https://api.github.com/repos/${owner}/${repo}/pulls/${number}`;
-  try {
-    const res = await fetch(api, {
-      credentials: "omit",
-      headers: { Accept: "application/vnd.github.diff" },
-    });
-    if (!res.ok) return "";
-    const text = await res.text();
-    if (!/^diff --git|\n@@ /.test(text)) return "";
-    return ghTruncate(text, GH_MAX_DIFF_CHARS);
-  } catch {
-    return "";
+function ghDomDiff() {
+  // Best-effort unified diff scraped from the rendered "Files changed" DOM,
+  // so summarizing a pull request never sends a cross-origin request off the
+  // page you are already viewing. Covers both the legacy server-rendered
+  // diff tables (.blob-code-*) and the newer viewer ([data-code-marker]).
+  // Returns "" when no diff rows are rendered; the caller then falls back
+  // to "(Diff unavailable.)".
+  const seen = new Set();
+  const lines = [];
+  const cells = document.querySelectorAll(
+    ".blob-code-addition .blob-code-inner, .blob-code-deletion .blob-code-inner, .blob-code-inner[data-code-marker]",
+  );
+  for (const cell of cells) {
+    if (!cell || seen.has(cell)) continue;
+    seen.add(cell);
+    const marker =
+      cell.getAttribute?.("data-code-marker") ||
+      (cell.closest?.(".blob-code-addition") ? "+" : "-");
+    if (marker !== "+" && marker !== "-") continue;
+    const text = (cell.innerText || cell.textContent || "").replace(/\s+$/, "");
+    if (!text) continue;
+    lines.push(`${marker} ${text.replace(/^[+-]\s?/, "")}`);
   }
+  if (!lines.length) return "";
+  return ghTruncate(lines.join("\n"), GH_MAX_DIFF_CHARS);
 }
 
 async function extractGitHub() {
@@ -105,7 +116,7 @@ async function extractGitHub() {
     }
 
     if (isPull) {
-      const diff = await ghFetchDiff(owner, repo, number);
+      const diff = ghDomDiff();
       content += diff
         ? `\nCode changes (unified diff):\n${diff}\n`
         : `\n(Diff unavailable.)\n`;

--- a/apogee-extension/lib/storage/activityAudit.js
+++ b/apogee-extension/lib/storage/activityAudit.js
@@ -1,10 +1,14 @@
 import { getSettings } from "./settings.js";
+import { shouldPersist } from "./pageCache.js";
 
 const AUDIT_LOG_KEY = "apogee_activity_audit_log";
 const MAX_AUDIT_ENTRIES = 20;
 
 /**
  * Record a page access event in local storage for transparency audit.
+ * Skips pages that must not persist (sensitive hosts, user private hosts,
+ * or "Don't save" mode), so the audit log itself never becomes a backdoor
+ * history of pages the user asked not to keep.
  * @param {{ title: string, url: string, contentLength: number, type: string }} event
  */
 export async function recordPageAccessEvent({
@@ -15,6 +19,7 @@ export async function recordPageAccessEvent({
 }) {
   if (typeof chrome === "undefined" || !chrome.storage?.local) return;
   try {
+    if (url && !(await shouldPersist(url))) return;
     const data = await chrome.storage.local.get([AUDIT_LOG_KEY]);
     const logs = Array.isArray(data[AUDIT_LOG_KEY]) ? data[AUDIT_LOG_KEY] : [];
     const entry = {
@@ -79,7 +84,7 @@ export async function getActivityAuditSummary() {
         : "Local execution active (Optional SponsorBlock API enabled for video segment skipping)",
     },
     storageRetention: {
-      saveHistory: settings.saveHistory !== "off",
+      saveHistory: settings.saveHistory !== false,
       cachedPagesCount: storageCount,
       autoWipePrivateHosts: (settings.privateHosts || []).length > 0,
       privateHostCount: (settings.privateHosts || []).length,

--- a/apogee-extension/tests/background/auditGate.test.js
+++ b/apogee-extension/tests/background/auditGate.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+
+test("service worker only audits pages that are allowed to persist (#181)", async () => {
+  const swCode = fs.readFileSync(
+    new URL("../../background/service-worker.js", import.meta.url),
+    "utf-8",
+  );
+
+  assert.ok(
+    /if \(persist\) \{\s*recordPageAccessEvent\(/.test(swCode),
+    "recordPageAccessEvent must be gated on persist so sensitive pages and " +
+      '"Don\'t save" sessions leave no title+URL trace in the audit log',
+  );
+});

--- a/apogee-extension/tests/extractors/github.test.js
+++ b/apogee-extension/tests/extractors/github.test.js
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
+import { readFileSync } from "node:fs";
 import { loadExtractors } from "./helpers/extractorHarness.js";
 
 const FILES = ["extractors/thread.js", "extractors/github.js"];
@@ -105,16 +106,8 @@ test("extractGitHub extracts issue title, state, description, and comments", asy
   );
 });
 
-test("extractGitHub extracts pull request metadata and fetches unified diff", async () => {
-  const diffPayload = `diff --git a/index.js b/index.js
-index 1234567..89abcdef 100644
---- a/index.js
-+++ b/index.js
-@@ -1,3 +1,3 @@
--const oldVal = 1;
-+const newVal = 2;`;
-
-  const { fetchStub, calls } = stubFetch(diffPayload);
+test("extractGitHub extracts pull request metadata with DOM-only diff and no network fetch", async () => {
+  const { fetchStub, calls } = stubFetch("unused");
   const html = `
     <!doctype html>
     <html>
@@ -127,6 +120,20 @@ index 1234567..89abcdef 100644
         <div class="timeline-comment">
           <a class="author">carol</a>
           <div class="comment-body">This pull request adds feature X.</div>
+        </div>
+        <div class="diff-table">
+          <table>
+            <tr>
+              <td class="blob-code blob-code-deletion">
+                <span class="blob-code-inner" data-code-marker="-">const oldVal = 1;</span>
+              </td>
+            </tr>
+            <tr>
+              <td class="blob-code blob-code-addition">
+                <span class="blob-code-inner">const newVal = 2;</span>
+              </td>
+            </tr>
+          </table>
         </div>
       </body>
     </html>
@@ -151,23 +158,18 @@ index 1234567..89abcdef 100644
   );
   assert.match(
     result.content,
-    /Code changes \(unified diff\):\ndiff --git a\/index\.js b\/index\.js/,
+    /Code changes \(unified diff\):\n- const oldVal = 1;\n\+ const newVal = 2;/,
   );
 
-  assert.strictEqual(calls.length, 1);
   assert.strictEqual(
-    calls[0].url,
-    "https://api.github.com/repos/owner/repo/pulls/101",
-  );
-  assert.strictEqual(calls[0].options.credentials, "omit");
-  assert.strictEqual(
-    calls[0].options.headers.Accept,
-    "application/vnd.github.diff",
+    calls.length,
+    0,
+    "PR extraction must not make any network request",
   );
 });
 
-test("extractGitHub handles pull request when diff request fails or returns unavailable diff", async () => {
-  const { fetchStub } = stubFetch("", { ok: false });
+test("extractGitHub reports diff unavailable when no diff DOM is rendered", async () => {
+  const { fetchStub, calls } = stubFetch("unused", { ok: false });
   const html = `
     <!doctype html>
     <html>
@@ -190,6 +192,11 @@ test("extractGitHub handles pull request when diff request fails or returns unav
 
   assert.strictEqual(result.type, "github");
   assert.match(result.content, /\(Diff unavailable\.\)/);
+  assert.strictEqual(
+    calls.length,
+    0,
+    "PR extraction must not make any network request",
+  );
 });
 
 test("extractGitHub returns null for unhandled pages or landing page without README", async () => {
@@ -218,4 +225,19 @@ test("extractGitHub returns null for unhandled pages or landing page without REA
     htmlNoReadme,
   );
   assert.strictEqual(await profilePage(), null);
+});
+
+test("github extractor source performs no network fetch (#180)", () => {
+  const source = readFileSync(
+    new URL("../../content/extractors/github.js", import.meta.url),
+    "utf8",
+  );
+  assert.ok(
+    !/\bfetch\s*\(/.test(source),
+    "github.js must not call fetch(); PR diffs are scraped from the page DOM",
+  );
+  assert.ok(
+    !source.includes("api.github.com"),
+    "github.js must not reference the undisclosed api.github.com egress",
+  );
 });

--- a/apogee-extension/tests/extractors/github.test.js
+++ b/apogee-extension/tests/extractors/github.test.js
@@ -236,8 +236,16 @@ test("github extractor source performs no network fetch (#180)", () => {
     !/\bfetch\s*\(/.test(source),
     "github.js must not call fetch(); PR diffs are scraped from the page DOM",
   );
-  assert.ok(
-    !source.includes("api.github.com"),
-    "github.js must not reference the undisclosed api.github.com egress",
-  );
+  // Any URL literal left in the extractor may only point at the page's own
+  // host. Hostnames are compared for exact equality (never a substring
+  // check) so lookalike hosts cannot slip through.
+  const urls = source.match(/https:\/\/[^\s"'`]+/g) || [];
+  for (const raw of urls) {
+    const host = new URL(raw.replace(/[.,;)\]]+$/, "")).hostname.toLowerCase();
+    assert.strictEqual(
+      host,
+      "github.com",
+      `github.js must not reference off-page host ${host}`,
+    );
+  }
 });

--- a/apogee-extension/tests/manifest.test.js
+++ b/apogee-extension/tests/manifest.test.js
@@ -116,3 +116,45 @@ test("declarativeNetRequest rule files exist and parse as valid JSON", () => {
     assert.ok(Array.isArray(rules), "Rule file content must be a JSON array");
   });
 });
+
+test("declared network egress matches the documented allow-list (#180)", () => {
+  // Every external host below is documented in PRIVACY.md ("Outbound Network
+  // Connection Details") and README/STORE-LISTING permission justifications.
+  // This test fails closed: adding a new egress host requires updating the
+  // docs and this list together, so an undisclosed call like the former
+  // api.github.com fetch cannot slip back in.
+  const documentedConnectSrc = new Set([
+    "'self'",
+    "http://127.0.0.1:*",
+    "http://localhost:*",
+    "https://huggingface.co",
+    "https://*.huggingface.co",
+    "https://*.hf.co",
+    "https://sponsor.ajay.app",
+    "https://api.bilibili.com",
+    "https://*.hdslb.com",
+    "https://public.api.bsky.app",
+  ]);
+
+  const csp = manifest.content_security_policy?.extension_pages || "";
+  const connectSrc = csp
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith("connect-src "));
+  assert.ok(connectSrc, "extension_pages CSP must declare connect-src");
+  const declared = connectSrc
+    .replace(/^connect-src\s+/, "")
+    .split(/\s+/)
+    .filter(Boolean);
+  assert.deepStrictEqual(
+    new Set(declared),
+    documentedConnectSrc,
+    "connect-src must exactly match the documented egress allow-list",
+  );
+
+  const manifestText = JSON.stringify(manifest);
+  assert.ok(
+    !manifestText.includes("api.github.com"),
+    "manifest must not declare api.github.com egress",
+  );
+});

--- a/apogee-extension/tests/manifest.test.js
+++ b/apogee-extension/tests/manifest.test.js
@@ -152,9 +152,20 @@ test("declared network egress matches the documented allow-list (#180)", () => {
     "connect-src must exactly match the documented egress allow-list",
   );
 
-  const manifestText = JSON.stringify(manifest);
-  assert.ok(
-    !manifestText.includes("api.github.com"),
-    "manifest must not declare api.github.com egress",
+  assert.deepStrictEqual(
+    new Set(manifest.host_permissions || []),
+    new Set(["http://127.0.0.1/*", "http://localhost/*"]),
+    "standing host_permissions must stay loopback-only",
+  );
+  assert.deepStrictEqual(
+    new Set(manifest.optional_host_permissions || []),
+    new Set([
+      "*://*.bilibili.com/*",
+      "*://*.hdslb.com/*",
+      "*://*.youtube.com/*",
+      "*://*.bsky.app/*",
+      "https://sponsor.ajay.app/*",
+    ]),
+    "optional_host_permissions must exactly match the documented set",
   );
 });

--- a/apogee-extension/tests/storage/activityAudit.test.js
+++ b/apogee-extension/tests/storage/activityAudit.test.js
@@ -86,3 +86,38 @@ test("getActivityAuditSummary reports SponsorBlock active by default", async () 
   assert.equal(summary.networkEgress.sponsorBlockActive, true);
   assert.equal(summary.networkEgress.zeroEgress, false);
 });
+
+test("recordPageAccessEvent skips sensitive pages even with history on (#181)", async () => {
+  storageMap.clear();
+  await recordPageAccessEvent({
+    title: "Inbox",
+    url: "https://mail.google.com/mail/u/0/#inbox",
+    contentLength: 900,
+    type: "generic",
+  });
+
+  const logs = await getPageAccessLog();
+  assert.equal(logs.length, 0);
+});
+
+test("recordPageAccessEvent skips all pages when saveHistory is off (#181)", async () => {
+  storageMap.clear();
+  await chrome.storage.local.set({ settings: { saveHistory: false } });
+  await recordPageAccessEvent({
+    title: "A normal article",
+    url: "https://example.com/article",
+    contentLength: 900,
+    type: "article",
+  });
+
+  const logs = await getPageAccessLog();
+  assert.equal(logs.length, 0);
+});
+
+test("getActivityAuditSummary reports saveHistory false when history is off", async () => {
+  storageMap.clear();
+  await chrome.storage.local.set({ settings: { saveHistory: false } });
+
+  const summary = await getActivityAuditSummary();
+  assert.equal(summary.storageRetention.saveHistory, false);
+});


### PR DESCRIPTION
## Summary
Fixes #180 and fixes #181.

#180: removed the undisclosed `api.github.com` fetch from the GitHub PR extractor (`content/extractors/github.js`). Diffs are now scraped best-effort from the rendered Files-changed DOM (`ghDomDiff()`), falling back to `(Diff unavailable.)`. No manifest/CSP/doc changes needed; PRIVACY.md's allow-list claim holds again. Added fail-closed tests: extractor source contains no `fetch(`, PR extraction makes zero network calls, and `connect-src` must exactly match the documented egress set.

#181: the page-access audit log no longer records sensitive pages or anything from "Don't save" sessions. `recordPageAccessEvent` is gated on `persist` at the service-worker call site plus a `shouldPersist(url)` guard inside the function. Also fixed the audit summary misreporting `saveHistory` (`!== "off"` was always true for boolean settings, now `!== false`).

## Test plan

- [x] `npm run format --prefix apogee-extension` (clean)
- [x] `npm run lint --prefix apogee-extension` (clean)
- [x] `npm test --prefix apogee-extension` (502 pass, 0 fail)
- [x] `npm run build --prefix apogee-extension` (both `dist/chrome` and `dist/firefox`)
- [ ] Manually exercised the change in a loaded browser extension

## Privacy impact

- [x] No new outbound network calls (removes one: `api.github.com` PR diff fetch)
- [x] Permissions unchanged, or all four of manifest / README / PRIVACY / store-listing updated together (no permission/doc changes required; egress surface strictly reduced)