### PR TITLE
fix: quick wins for audit findings

### DIFF
--- a/apogee-extension/lib/extract/pageExtraction.js
+++ b/apogee-extension/lib/extract/pageExtraction.js
@@ -1,5 +1,5 @@
 import { UserFacingError } from "../util/userError.js";
-import { MAX_UPLOAD_FILE_BYTES, MAX_UPLOAD_FILE_MB } from "./fileLimits.js";
+import { MAX_UPLOAD_FILE_BYTES } from "./fileLimits.js";
 
 // Pages the browser itself refuses to let extensions script, even though they are ordinary https URLs. Without this the raw engine error ("The extensions gallery cannot be scripted.") leaks into the popup.
 const BLOCKED_PAGES = [
@@ -111,9 +111,6 @@ export async function extractFromActiveTab(tab) {
 }
 
 // Chrome extension messaging has an internal size ceiling. Base64 costs 1.33× and the chunked String.fromCharCode loop holds a second full copy, so we cap the raw PDF size well below the point where sendMessage would silently fail.
-export const MAX_PDF_SIZE_BYTES = MAX_UPLOAD_FILE_BYTES;
-export const MAX_PDF_SIZE_MB = MAX_UPLOAD_FILE_MB;
-
 export async function extractPdfContent(tab) {
   const results = await chrome.scripting.executeScript({
     target: { tabId: tab.id },
@@ -135,7 +132,7 @@ export async function extractPdfContent(tab) {
       }
       return btoa(binary);
     },
-    args: [MAX_PDF_SIZE_BYTES],
+    args: [MAX_UPLOAD_FILE_BYTES],
   });
   const pdfBase64 = results?.[0]?.result;
   if (!pdfBase64) throw new UserFacingError("Could not download PDF.");

--- a/apogee-extension/lib/storage/activityAudit.js
+++ b/apogee-extension/lib/storage/activityAudit.js
@@ -62,7 +62,10 @@ export async function getActivityAuditSummary() {
     try {
       const allData = await chrome.storage.local.get(null);
       storageCount = Object.keys(allData).filter(
-        (k) => k.startsWith("summary_") || k.startsWith("cache_"),
+        (k) =>
+          k.startsWith("summary:") ||
+          k.startsWith("suggested-prompts:") ||
+          k.startsWith("content:"),
       ).length;
     } catch {
       storageCount = 0;

--- a/apogee-extension/lib/util/permissions.js
+++ b/apogee-extension/lib/util/permissions.js
@@ -5,7 +5,7 @@
  */
 export async function hasHostPermissions(origins) {
   if (typeof chrome === "undefined" || !chrome.permissions?.contains) {
-    return true;
+    return false;
   }
   try {
     return await new Promise((resolve) => {

--- a/apogee-extension/tests/storage/activityAudit.test.js
+++ b/apogee-extension/tests/storage/activityAudit.test.js
@@ -121,3 +121,17 @@ test("getActivityAuditSummary reports saveHistory false when history is off", as
   const summary = await getActivityAuditSummary();
   assert.equal(summary.storageRetention.saveHistory, false);
 });
+
+test("getActivityAuditSummary counts real cached-page keys (#208)", async () => {
+  storageMap.clear();
+  await chrome.storage.local.set({
+    "summary:bullets:auto:m:abc": "text",
+    "suggested-prompts:bullets:auto:m:abc": ["q?"],
+    "content:def": { title: "t" },
+    cacheOrder: [{ s: "summary:bullets:auto:m:abc" }],
+    unrelated: 1,
+  });
+
+  const summary = await getActivityAuditSummary();
+  assert.equal(summary.storageRetention.cachedPagesCount, 3);
+});

--- a/apogee-extension/tests/ui/popupMessageGate.test.js
+++ b/apogee-extension/tests/ui/popupMessageGate.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+
+test("popup onMessage listeners validate the sender (#207)", async () => {
+  const appCode = fs.readFileSync(
+    new URL("../../ui/app.js", import.meta.url),
+    "utf-8",
+  );
+
+  const listeners =
+    appCode.match(
+      /chrome\.runtime\.onMessage\.addListener\(\(message, sender\) => \{/g,
+    ) || [];
+  assert.ok(
+    listeners.length >= 2,
+    "expected at least two sender-aware popup listeners",
+  );
+
+  const guards =
+    appCode.match(
+      /if \(sender\?\.id && sender\.id !== chrome\.runtime\.id\) return;/g,
+    ) || [];
+  assert.ok(
+    guards.length >= listeners.length,
+    "every popup onMessage listener must reject foreign senders",
+  );
+});

--- a/apogee-extension/tests/util/permissions.test.js
+++ b/apogee-extension/tests/util/permissions.test.js
@@ -8,12 +8,12 @@ import {
   ensurePermissionsForUrl,
 } from "../../lib/util/permissions.js";
 
-test("hasHostPermissions returns true when chrome.permissions is undefined", async () => {
+test("hasHostPermissions returns false when chrome.permissions is undefined (#209)", async () => {
   const originalChrome = globalThis.chrome;
   delete globalThis.chrome;
   try {
     const result = await hasHostPermissions(["*://*.bilibili.com/*"]);
-    assert.strictEqual(result, true);
+    assert.strictEqual(result, false);
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/apogee-extension/ui/app.html
+++ b/apogee-extension/ui/app.html
@@ -193,7 +193,6 @@
 
           <div class="header-actions">
             <button
-              id="summaryThemeToggleBtn"
               class="icon-btn side-panel-theme-btn"
               type="button"
               aria-label="Toggle theme"
@@ -510,7 +509,7 @@
               >
             </label>
 
-            <label class="radio-option" id="transformersProviderOption">
+            <label class="radio-option">
               <input type="radio" name="provider" value="transformers" />
               <span
                 >In-Browser AI (CPU)
@@ -525,7 +524,7 @@
               >
             </label>
 
-            <label class="radio-option" id="llamacppProviderOption">
+            <label class="radio-option">
               <input type="radio" name="provider" value="llamacpp" />
               <span
                 >Local LLaMA.cpp
@@ -777,7 +776,7 @@
             <div id="clearDataStatus" class="clear-data-status"></div>
           </div>
 
-          <div class="settings-card" id="privacyAuditCard">
+          <div class="settings-card">
             <div class="card-title">
               <span class="ico" data-ico="activity" aria-hidden="true"></span>
               <span>Activity &amp; Privacy Audit</span>

--- a/apogee-extension/ui/app.js
+++ b/apogee-extension/ui/app.js
@@ -367,7 +367,8 @@ chrome.storage.onChanged.addListener((changes, area) => {
   setSuggestedQuestions(questions);
 });
 
-chrome.runtime.onMessage.addListener((message) => {
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (sender?.id && sender.id !== chrome.runtime.id) return;
   if (
     message.type === "suggested-prompts-ready" &&
     message.promptsCacheKey === currentPromptsCacheKey
@@ -743,7 +744,8 @@ async function getPageData(tab) {
 
 let modelProgressHideTimer = null;
 
-chrome.runtime.onMessage.addListener((message) => {
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (sender?.id && sender.id !== chrome.runtime.id) return;
   if (message.type === "selection-summary-started" && isSidePanelSurface) {
     window.location.reload();
     return;


### PR DESCRIPTION
## Summary
Fixes #203, fixes #204, fixes #207, fixes #208, fixes #209. Each fix is under 10 lines of production code.

- #203: deleted the dead `MAX_PDF_SIZE_BYTES` / `MAX_PDF_SIZE_MB` aliases; `pageExtraction.js` uses `MAX_UPLOAD_FILE_BYTES` directly.
- #204: dropped orphaned ids with zero JS/CSS/test references (`summaryThemeToggleBtn`, `transformersProviderOption`, `llamacppProviderOption`, `privacyAuditCard`). Test-pinned ids (`openSidePanelBtn*`, `sidePanelThemeToggleBtn`) left alone.
- #207: both popup `onMessage` listeners now reject foreign senders (`sender.id !== chrome.runtime.id`), matching SW/offscreen/content; static regression test added.
- #208: retention count matches real key prefixes (`summary:`, `suggested-prompts:`, `content:`) instead of the nonexistent `summary_*` / `cache_*`; count test added.
- #209: `hasHostPermissions` fails closed (`false`) when the permissions API is absent; existing test expectation updated.

Left out deliberately: #205/#206/#210/#211/#212 need docs, design decisions, or larger changes.

## Test plan

- [x] `npm run format --prefix apogee-extension` (clean)
- [x] `npm run lint --prefix apogee-extension` (clean)
- [x] `npm test --prefix apogee-extension` (517 pass, 0 fail)
- [x] `npm run build --prefix apogee-extension` (both `dist/chrome` and `dist/firefox`)
- [ ] Manually exercised the change in a loaded browser extension

## Privacy impact

- [x] No new outbound network calls
- [x] Permissions unchanged, or all four of manifest / README / PRIVACY / store-listing updated together (no permission changes)