### PR TITLE
feat(edge): Edge Add-ons packaging for v0.2.1

### DIFF
--- a/apogee-extension/package.json
+++ b/apogee-extension/package.json
@@ -11,13 +11,15 @@
     "dev": "vite build --watch",
     "fetch:model-libs": "node scripts/model-libs.mjs",
     "build:chrome": "TARGET_BROWSER=chrome vite build",
+    "build:edge": "TARGET_BROWSER=edge vite build",
     "build:firefox": "TARGET_BROWSER=firefox vite build",
     "build": "npm run build:chrome && npm run build:firefox",
     "test": "node --test",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "package": "npm run build && node -e 'const fs = require(\"fs\"); const v = JSON.parse(fs.readFileSync(\"manifest.json\")).version; const exec = require(\"child_process\").execSync; exec(\"npx web-ext build --source-dir dist/chrome --artifacts-dir ../ --overwrite-dest --filename apogee-\" + v + \"-chrome.zip\", {stdio: \"inherit\"}); exec(\"npx web-ext build --source-dir dist/firefox --artifacts-dir ../ --overwrite-dest --filename apogee-\" + v + \"-mozilla.xpi\", {stdio: \"inherit\"});'"
+    "package": "npm run build && node -e 'const fs = require(\"fs\"); const v = JSON.parse(fs.readFileSync(\"manifest.json\")).version; const exec = require(\"child_process\").execSync; exec(\"npx web-ext build --source-dir dist/chrome --artifacts-dir ../ --overwrite-dest --filename apogee-\" + v + \"-chrome.zip\", {stdio: \"inherit\"}); exec(\"npx web-ext build --source-dir dist/firefox --artifacts-dir ../ --overwrite-dest --filename apogee-\" + v + \"-mozilla.xpi\", {stdio: \"inherit\"});'",
+    "package:edge": "npm run build:edge && node -e 'const fs = require(\"fs\"); const v = JSON.parse(fs.readFileSync(\"manifest.json\")).version; const exec = require(\"child_process\").execSync; exec(\"npx web-ext build --source-dir dist/edge --artifacts-dir ../ --overwrite-dest --filename apogee-\" + v + \"-edge.zip\", {stdio: \"inherit\"});'"
   },
   "dependencies": {
     "@huggingface/transformers": "4.2.0",

--- a/apogee-extension/vite.config.js
+++ b/apogee-extension/vite.config.js
@@ -51,19 +51,22 @@ function copyStaticPlugin(targetBrowser) {
 }
 
 function bundleModelLibsPlugin(targetBrowser) {
+  // Edge is Chromium-based, so it shares the Chrome build path
+  // (offscreen, service_worker, model libs). Only Firefox diverges.
+  const isChromium = targetBrowser === "chrome" || targetBrowser === "edge";
   let libs = [];
   return {
     name: "bundle-webllm-model-libs",
     async buildStart() {
-      if (targetBrowser !== "chrome") return;
+      if (!isChromium) return;
       libs = await ensureModelLibs();
     },
     closeBundle() {
-      if (targetBrowser !== "chrome") return;
+      if (!isChromium) return;
       for (const { file, path } of libs) {
         cpSync(
           path,
-          resolve(__dirname, `dist/chrome/assets/model-libs/${file}`),
+          resolve(__dirname, `dist/${targetBrowser}/assets/model-libs/${file}`),
         );
       }
     },

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
   "scripts": {
     "install:extension": "npm install --prefix apogee-extension",
     "build": "npm run build --prefix apogee-extension",
+    "build:edge": "npm run build:edge --prefix apogee-extension",
     "test": "npm test --prefix apogee-extension",
     "lint": "npm run lint --prefix apogee-extension",
     "format": "npm run format --prefix apogee-extension",
     "dev": "npm run dev --prefix apogee-extension",
-    "package": "npm run package --prefix apogee-extension"
+    "package": "npm run package --prefix apogee-extension",
+    "package:edge": "npm run package:edge --prefix apogee-extension"
   }
 }


### PR DESCRIPTION
Branched from tag v0.2.1 (3bd2165) to prepare the Microsoft Edge Add-ons upload.

## Changes
- apogee-extension/package.json: add build:edge (TARGET_BROWSER=edge vite build) and package:edge (web-ext build dist/edge -> apogee-0.2.1-edge.zip). Existing build/package untouched.
- apogee-extension/vite.config.js: treat edge as Chromium (same as chrome: offscreen, service_worker, model libs); generalize model-libs output to dist/<target>/assets/model-libs.
- package.json (root): expose build:edge and package:edge.

## Verification
- npm run build:edge succeeds; dist/edge/manifest.json identical to dist/chrome/manifest.json.
- npm run package:edge produces apogee-0.2.1-edge.zip with manifest.json at zip root (per https://learn.microsoft.com/en-us/microsoft-edge/extensions/publish/publish-extension).
- build:firefox still passes; prettier check passes.
- Zip is gitignored build artifact; upload apogee-0.2.1-edge.zip via Partner Center > Create new extension > Upload package (.zip file).

## Usage
npm run package:edge