### PR TITLE
fix: audit LOWs (sender guards, offscreen tab gate, port validation)

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -1514,6 +1514,14 @@ const activeSidePanelTabs = new Set();
 
 if (typeof chrome !== "undefined" && chrome.runtime?.onConnect?.addListener) {
   chrome.runtime.onConnect.addListener((port) => {
+    // Ports are same-extension by construction, but validate the sender like
+    // the onMessage handlers do; unknown-name ports are already dropped below.
+    if (port.sender?.id !== chrome.runtime.id) {
+      try {
+        port.disconnect();
+      } catch {}
+      return;
+    }
     if (port.name && port.name.startsWith("side-panel-tab-")) {
       const tabId = parseInt(port.name.replace("side-panel-tab-", ""), 10);
       if (!isNaN(tabId)) {

--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -1608,7 +1608,7 @@ if (typeof chrome !== "undefined" && chrome.runtime?.onConnect?.addListener) {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.target !== "service-worker") return false;
 
-  if (sender.id !== chrome.runtime.id) return false;
+  if (sender?.id !== chrome.runtime.id) return false;
 
   const ALLOWED_CONTENT_SCRIPT_ACTIONS = new Set([
     "sponsorblock-segments",

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -716,7 +716,7 @@ chrome.runtime.onConnect.addListener((port) => {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.target !== "offscreen") return false;
 
-  if (sender.id !== chrome.runtime.id) return false;
+  if (sender?.id !== chrome.runtime.id) return false;
 
   const handler = async () => {
     try {

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -658,6 +658,14 @@ async function runStream(streamId, pending, stream) {
 }
 
 chrome.runtime.onConnect.addListener((port) => {
+  // Same sender validation as the onMessage handlers; unknown-name ports are
+  // already dropped below.
+  if (port.sender?.id !== chrome.runtime.id) {
+    try {
+      port.disconnect();
+    } catch {}
+    return;
+  }
   if (!port.name.startsWith("offscreen-stream-")) return;
 
   const streamId = port.name.replace("offscreen-stream-", "");

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -718,6 +718,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   if (sender?.id !== chrome.runtime.id) return false;
 
+  // The service worker is the only legitimate sender (every target:
+  // "offscreen" call site originates there). Tab-hosted contexts must not
+  // invoke local-compute actions directly, so reject them outright rather
+  // than allow-listing actions per sender.
+  if (sender.tab) return false;
+
   const handler = async () => {
     try {
       switch (message.action) {


### PR DESCRIPTION
Hardening follow-ups from the repo-wide security audit. One commit per fix, full suite (556 tests) + eslint green.

- Tolerate undefined sender in onMessage guards (service worker + offscreen): `sender?.id`, matching popup/content.
- Reject tab-originated messages in the offscreen handler: only the service worker legitimately sends `target: offscreen`, so tab-hosted contexts are refused outright.
- Validate `port.sender` in both onConnect handlers, disconnecting foreign senders; unknown port names were already dropped.