### PR TITLE
fix: audit LOWs (strict sender reject, port tab scoping)

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -1522,6 +1522,15 @@ if (typeof chrome !== "undefined" && chrome.runtime?.onConnect?.addListener) {
       } catch {}
       return;
     }
+    // All port families here (popup-lifecycle, side-panel-tab-*, popup-stream-*)
+    // are opened by extension pages, never by tab-hosted contexts — the tab id
+    // for side-panel ports travels in the port name instead.
+    if (port.sender?.tab) {
+      try {
+        port.disconnect();
+      } catch {}
+      return;
+    }
     if (port.name && port.name.startsWith("side-panel-tab-")) {
       const tabId = parseInt(port.name.replace("side-panel-tab-", ""), 10);
       if (!isNaN(tabId)) {

--- a/apogee-extension/content/content.js
+++ b/apogee-extension/content/content.js
@@ -88,7 +88,7 @@ if (
   chrome.runtime.onMessage
 ) {
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (sender.id && sender.id !== chrome.runtime.id) return;
+    if (sender?.id !== chrome.runtime.id) return;
     if (message && message.action === "extract-page-content") {
       extractPageContent()
         .then((data) => sendResponse(data))

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -666,6 +666,14 @@ chrome.runtime.onConnect.addListener((port) => {
     } catch {}
     return;
   }
+  // Stream ports are opened by the service-worker relay only; tab-hosted
+  // contexts must not siphon stream text, mirroring the onMessage tab reject.
+  if (port.sender?.tab) {
+    try {
+      port.disconnect();
+    } catch {}
+    return;
+  }
   if (!port.name.startsWith("offscreen-stream-")) return;
 
   const streamId = port.name.replace("offscreen-stream-", "");

--- a/apogee-extension/tests/ui/popupMessageGate.test.js
+++ b/apogee-extension/tests/ui/popupMessageGate.test.js
@@ -18,9 +18,7 @@ test("popup onMessage listeners validate the sender (#207)", async () => {
   );
 
   const guards =
-    appCode.match(
-      /if \(sender\?\.id && sender\.id !== chrome\.runtime\.id\) return;/g,
-    ) || [];
+    appCode.match(/if \(sender\?\.id !== chrome\.runtime\.id\) return;/g) || [];
   assert.ok(
     guards.length >= listeners.length,
     "every popup onMessage listener must reject foreign senders",

--- a/apogee-extension/ui/app.js
+++ b/apogee-extension/ui/app.js
@@ -379,7 +379,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
 });
 
 chrome.runtime.onMessage.addListener((message, sender) => {
-  if (sender?.id && sender.id !== chrome.runtime.id) return;
+  if (sender?.id !== chrome.runtime.id) return;
   if (
     message.type === "suggested-prompts-ready" &&
     message.promptsCacheKey === currentPromptsCacheKey
@@ -764,7 +764,7 @@ async function getPageData(tab) {
 let modelProgressHideTimer = null;
 
 chrome.runtime.onMessage.addListener((message, sender) => {
-  if (sender?.id && sender.id !== chrome.runtime.id) return;
+  if (sender?.id !== chrome.runtime.id) return;
   if (message.type === "selection-summary-started" && isSidePanelSurface) {
     window.location.reload();
     return;


### PR DESCRIPTION
Message/port hardening follow-ups from the repo-wide security audit. One commit per fix, full suite (556 tests) + eslint + prettier green.

- Strict sender reject in popup listeners (fail-closed on missing sender id; gate test updated to pin the strict form).
- Strict sender reject in content-script listener (also fixes non-optional access).
- Reject tab-originated ports in offscreen onConnect (mirrors the onMessage tab reject; SW relay ports carry no tab).
- Reject tab-originated ports in service-worker onConnect (all three families — popup-lifecycle, side-panel-tab-*, popup-stream-* — are opened by extension pages; side-panel tab id travels in the port name).