### PR TITLE
fix: sender/tab gates on highlight, popup, content listeners

### DIFF
--- a/apogee-extension/content/content.js
+++ b/apogee-extension/content/content.js
@@ -89,6 +89,9 @@ if (
 ) {
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (sender?.id !== chrome.runtime.id) return;
+    // Extraction requests come from the extension page via tabs.sendMessage
+    // (no sender tab); tab-hosted contexts must not pull page text this way.
+    if (sender.tab) return;
     if (message && message.action === "extract-page-content") {
       extractPageContent()
         .then((data) => sendResponse(data))

--- a/apogee-extension/content/highlight.js
+++ b/apogee-extension/content/highlight.js
@@ -187,7 +187,10 @@ if (
   chrome.runtime.onMessage
 ) {
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (sender.id && sender.id !== chrome.runtime.id) return;
+    if (sender?.id !== chrome.runtime.id) return;
+    // Highlight requests come from the extension page via tabs.sendMessage
+    // (no sender tab); tab-hosted contexts must not trigger page highlights.
+    if (sender.tab) return;
     if (message && message.action === "apogee-highlight") {
       const result = performHighlight(message.chunkText);
       sendResponse(result);

--- a/apogee-extension/ui/app.js
+++ b/apogee-extension/ui/app.js
@@ -380,6 +380,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
 
 chrome.runtime.onMessage.addListener((message, sender) => {
   if (sender?.id !== chrome.runtime.id) return;
+  if (sender.tab) return;
   if (
     message.type === "suggested-prompts-ready" &&
     message.promptsCacheKey === currentPromptsCacheKey
@@ -765,6 +766,7 @@ let modelProgressHideTimer = null;
 
 chrome.runtime.onMessage.addListener((message, sender) => {
   if (sender?.id !== chrome.runtime.id) return;
+  if (sender.tab) return;
   if (message.type === "selection-summary-started" && isSidePanelSurface) {
     window.location.reload();
     return;


### PR DESCRIPTION
Message-hardening follow-ups from the repo-wide security audit. One commit per fix, full suite (556 tests) + eslint + prettier green. Senders verified before gating: all three listeners are legitimately reached only by extension pages via tabs.sendMessage (no sender tab).

- Strict sender + tab reject in highlight listener (was the last permissive `sender.id &&` gate; file is filename-injected so earlier sweeps missed it).
- Reject tab-originated messages in popup listeners (blocks planted suggested-questions / UI spoofing from tab contexts).
- Reject tab-originated messages in content listener (blocks pulling page text via extract-page-content from tab contexts).