### PR TITLE
fix: validated-input LOWs (providers, finalize text, model name, settings schema)

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -32,7 +32,10 @@ import {
 import { truncateForPrompt } from "../lib/summarize/chunk.js";
 import { parseSuggestedQuestions } from "../lib/summarize/questions.js";
 import { extractPdfText } from "../lib/extract/pdfExtract.js";
-import { MAX_UPLOAD_FILE_BYTES } from "../lib/extract/fileLimits.js";
+import {
+  MAX_FINALIZE_TEXT_CHARS,
+  MAX_UPLOAD_FILE_BYTES,
+} from "../lib/extract/fileLimits.js";
 import {
   recordPageAccessEvent,
   getActivityAuditSummary,
@@ -1336,6 +1339,13 @@ async function runSuggestQuestionsJob(payload) {
 
 async function finalizeSummaryJob({ finalize, model, title, url, text }) {
   if (!finalize) return;
+  // stream-finished text arrives via extension messaging and fans out into
+  // cache/history/view-state: bound it at the trust boundary before use.
+  if (typeof text === "string" && text.length > MAX_FINALIZE_TEXT_CHARS) {
+    text =
+      `${text.slice(0, MAX_FINALIZE_TEXT_CHARS).trim()}\n\n` +
+      `[...summary truncated to the first ${MAX_FINALIZE_TEXT_CHARS} characters...]`;
+  }
   const {
     cacheKey,
     promptsCacheKey,

--- a/apogee-extension/lib/constants.js
+++ b/apogee-extension/lib/constants.js
@@ -114,6 +114,11 @@ export const CUSTOM_INSTRUCTIONS_MAX_CHARS = 2000;
 
 export const PRIVATE_HOSTS_MAX_CHARS = 1000;
 
+// Model-name free text (llama.cpp server model, Ollama tag override). Real
+// names are tens of chars; cap so a pasted blob cannot ride along into
+// loopback request bodies and stored settings.
+export const MODEL_NAME_MAX_CHARS = 100;
+
 export const TRANSLATION_ENGINES = { LLM: "llm", OPUS: "opus" };
 const DEFAULT_TRANSLATION_ENGINE = TRANSLATION_ENGINES.OPUS;
 

--- a/apogee-extension/lib/engines/providers.js
+++ b/apogee-extension/lib/engines/providers.js
@@ -1,5 +1,9 @@
 import { UserFacingError } from "../util/userError.js";
 import {
+  DEFAULT_OLLAMA_PORT,
+  validateLoopbackUrl,
+} from "../util/ollamaHost.js";
+import {
   PROVIDERS,
   DEFAULT_PROVIDER,
   DEFAULT_OLLAMA_HOST,
@@ -268,7 +272,17 @@ class TransformersProvider {
 class DirectOllamaProvider {
   constructor(model, host) {
     this.model = model;
-    this.host = (host || DEFAULT_OLLAMA_HOST).replace(/\/+$/, "");
+    // Defense in depth: the service worker re-validates and overwrites this
+    // host before any fetch, but never persist or send a value the shared
+    // validator would reject.
+    try {
+      this.host = validateLoopbackUrl(host || DEFAULT_OLLAMA_HOST, {
+        label: "Ollama",
+        defaultPort: DEFAULT_OLLAMA_PORT,
+      });
+    } catch {
+      this.host = DEFAULT_OLLAMA_HOST;
+    }
   }
 
   summarize({
@@ -336,7 +350,22 @@ class DirectOllamaProvider {
 class DirectLlamaCppProvider {
   constructor(model, host, apiKey) {
     this.model = model;
-    this.host = (host || DEFAULT_LLAMACPP_HOST).replace(/\/+$/, "");
+    // Same shared validator as the Ollama provider above, with the llama.cpp
+    // default port derived from DEFAULT_LLAMACPP_HOST.
+    let llamaDefaultPort = "8080";
+    try {
+      llamaDefaultPort = new URL(DEFAULT_LLAMACPP_HOST).port || "8080";
+    } catch {
+      // Keep the built-in fallback above.
+    }
+    try {
+      this.host = validateLoopbackUrl(host || DEFAULT_LLAMACPP_HOST, {
+        label: "llama.cpp",
+        defaultPort: llamaDefaultPort,
+      });
+    } catch {
+      this.host = DEFAULT_LLAMACPP_HOST;
+    }
     this.apiKey = apiKey || "";
   }
 

--- a/apogee-extension/lib/extract/fileLimits.js
+++ b/apogee-extension/lib/extract/fileLimits.js
@@ -33,6 +33,11 @@ export const MAX_DOCX_ENTRIES = 10000;
 // result string itself becomes the OOM vector.
 export const MAX_PDF_TEXT_CHARS = 25 * 1024 * 1024;
 
+// Finished-summary backstop (#211 follow-up). stream-finished text arrives
+// via extension messaging and is written to cache/history, so bound it
+// before it fans out: real summaries are kilobytes, 1 MB is generous.
+export const MAX_FINALIZE_TEXT_CHARS = 1024 * 1024;
+
 // Pasted-text and plain-text file ceiling (#211). file.size bounds the upload
 // (~50 MB string), but two post-read text paths were unbounded: file.text()
 // for txt/md/json/html and the pasted-text dialog. A multi-MB string here

--- a/apogee-extension/lib/storage/settings.js
+++ b/apogee-extension/lib/storage/settings.js
@@ -1,6 +1,30 @@
-import { DEFAULT_SETTINGS } from "../constants.js";
+import { DEFAULT_SETTINGS, PROVIDERS } from "../constants.js";
+import { validateLlamaHost, validateOllamaHost } from "../util/ollamaHost.js";
+
+const PROVIDER_VALUES = new Set(Object.values(PROVIDERS));
+
+function sanitizeSettings(settings) {
+  const clean = { ...settings };
+  // A corrupted store must not flip the provider or loopback hosts: unknown
+  // providers fall back to the default, and hosts go through the same shared
+  // validator the service worker enforces at request time.
+  if (!PROVIDER_VALUES.has(clean.provider)) {
+    clean.provider = DEFAULT_SETTINGS.provider;
+  }
+  try {
+    clean.ollamaHost = validateOllamaHost(clean.ollamaHost);
+  } catch {
+    clean.ollamaHost = DEFAULT_SETTINGS.ollamaHost;
+  }
+  try {
+    clean.llamaHost = validateLlamaHost(clean.llamaHost);
+  } catch {
+    clean.llamaHost = DEFAULT_SETTINGS.llamaHost;
+  }
+  return clean;
+}
 
 export async function getSettings() {
   const stored = await chrome.storage.local.get("settings");
-  return { ...DEFAULT_SETTINGS, ...(stored.settings || {}) };
+  return sanitizeSettings({ ...DEFAULT_SETTINGS, ...(stored.settings || {}) });
 }

--- a/apogee-extension/lib/summarize/prompts.js
+++ b/apogee-extension/lib/summarize/prompts.js
@@ -459,8 +459,6 @@ export function buildYoutubeAssemblyPrompt(
   url,
   notes,
   lastAvailableSeconds,
-  // eslint-disable-next-line no-unused-vars
-  mode,
 ) {
   const lastTimestamp = formatSecondsAsTimestamp(lastAvailableSeconds);
   // Sanitize before deriving jump-link templates: the URL is interpolated

--- a/apogee-extension/lib/summarize/youtubeSummarize.js
+++ b/apogee-extension/lib/summarize/youtubeSummarize.js
@@ -26,7 +26,7 @@ function lastAvailableSecondsIn(text) {
 }
 
 export async function* summarizeYoutube(
-  { text, title, url, mode, model, host, signal, language, customInstructions },
+  { text, title, url, model, host, signal, language, customInstructions },
   {
     chunkTextFn = chunkText,
     chatStreamFn = chatStream,
@@ -61,7 +61,6 @@ export async function* summarizeYoutube(
             url,
             noteText,
             lastAvailableSeconds,
-            mode,
           ),
       customInstructions,
     );

--- a/apogee-extension/lib/util/ollamaHost.js
+++ b/apogee-extension/lib/util/ollamaHost.js
@@ -1,3 +1,5 @@
+import { DEFAULT_LLAMACPP_HOST } from "../constants.js";
+
 const ALLOWED_OLLAMA_HOSTS = new Set(["127.0.0.1", "localhost"]);
 const DEFAULT_OLLAMA_PORT = "11434";
 
@@ -39,5 +41,20 @@ export function validateOllamaHost(host) {
   return validateLoopbackUrl(host, {
     label: "Ollama",
     defaultPort: DEFAULT_OLLAMA_PORT,
+  });
+}
+
+function llamaDefaultPort() {
+  try {
+    return new URL(DEFAULT_LLAMACPP_HOST).port || "8080";
+  } catch {
+    return "8080";
+  }
+}
+
+export function validateLlamaHost(host) {
+  return validateLoopbackUrl(host, {
+    label: "llama.cpp",
+    defaultPort: llamaDefaultPort(),
   });
 }

--- a/apogee-extension/tests/extract/fileLimits.test.js
+++ b/apogee-extension/tests/extract/fileLimits.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  MAX_FINALIZE_TEXT_CHARS,
   MAX_PASTED_CHARS,
   MAX_UPLOAD_FILE_BYTES,
   MAX_UPLOAD_FILE_MB,
@@ -49,4 +50,8 @@ test("truncatePastedText truncates with a note past the ceiling (#211)", () => {
   assert.equal(truncated, true);
   assert.ok(text.length < MAX_PASTED_CHARS + 1000);
   assert.match(text, /\[\.\.\.pasted content truncated/);
+});
+
+test("finished-summary backstop is a generous fixed ceiling", () => {
+  assert.equal(MAX_FINALIZE_TEXT_CHARS, 1024 * 1024);
 });

--- a/apogee-extension/tests/storage/settings.test.js
+++ b/apogee-extension/tests/storage/settings.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { getSettings } from "../../lib/storage/settings.js";
+import {
+  DEFAULT_LLAMACPP_HOST,
+  DEFAULT_OLLAMA_HOST,
+  DEFAULT_SETTINGS,
+} from "../../lib/constants.js";
+
+function installFakeStorage(settings) {
+  globalThis.chrome = {
+    storage: {
+      local: {
+        get: async () => ({ settings }),
+      },
+    },
+  };
+}
+
+test("getSettings returns defaults when nothing is stored", async () => {
+  installFakeStorage(undefined);
+  const settings = await getSettings();
+  assert.equal(settings.provider, DEFAULT_SETTINGS.provider);
+  assert.equal(settings.ollamaHost, DEFAULT_OLLAMA_HOST);
+  assert.equal(settings.llamaHost, DEFAULT_LLAMACPP_HOST);
+});
+
+test("getSettings preserves valid providers and loopback hosts", async () => {
+  installFakeStorage({
+    provider: "local",
+    ollamaHost: "http://127.0.0.1:11434",
+    llamaHost: "http://localhost:8080",
+  });
+  const settings = await getSettings();
+  assert.equal(settings.provider, "local");
+  assert.equal(settings.ollamaHost, "http://127.0.0.1:11434");
+  assert.equal(settings.llamaHost, "http://localhost:8080");
+});
+
+test("getSettings falls back on unknown provider and non-loopback hosts", async () => {
+  installFakeStorage({
+    provider: "evil-cloud",
+    ollamaHost: "http://example.com:11434",
+    llamaHost: "https://127.0.0.1:8080",
+  });
+  const settings = await getSettings();
+  assert.equal(settings.provider, DEFAULT_SETTINGS.provider);
+  assert.equal(settings.ollamaHost, DEFAULT_OLLAMA_HOST);
+  assert.equal(settings.llamaHost, DEFAULT_LLAMACPP_HOST);
+});

--- a/apogee-extension/ui/app.js
+++ b/apogee-extension/ui/app.js
@@ -24,6 +24,7 @@ import {
   SUMMARY_LANGUAGES,
   CUSTOM_INSTRUCTIONS_MAX_CHARS,
   PRIVATE_HOSTS_MAX_CHARS,
+  MODEL_NAME_MAX_CHARS,
   isVideoType,
 } from "../lib/constants.js";
 import { getSettings } from "../lib/storage/settings.js";
@@ -2814,7 +2815,9 @@ llamaApiKeyInput?.addEventListener("change", async () => {
 });
 
 llamaModelInput?.addEventListener("change", async () => {
-  await saveSettings({ llamaModel: llamaModelInput.value.trim() });
+  const value = llamaModelInput.value.slice(0, MODEL_NAME_MAX_CHARS).trim();
+  llamaModelInput.value = value;
+  await saveSettings({ llamaModel: value });
 });
 
 promptsCloseBtn?.addEventListener("click", () => {


### PR DESCRIPTION
Hardening follow-ups from the repo-wide security audit. One commit per fix, full suite (560 tests) + eslint + prettier green.

- Validate host in direct provider constructors (fallback to defaults; service worker still re-validates downstream).
- Cap stream-finished text at the finalize boundary (new 1 MB MAX_FINALIZE_TEXT_CHARS ceiling, truncate-plus-note).
- Cap llamaModel free-text input (new 100-char MODEL_NAME_MAX_CHARS, mirroring the custom-instructions pattern).
- Schema-validate settings on read (unknown provider and non-loopback hosts fall back to defaults; new settings.test.js).
- Drop unused mode param from buildYoutubeAssemblyPrompt (removes the eslint-disable too).