### PR TITLE
chore: pin release-as to 0.2.1 until first manual release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "include-component-in-tag": false,
   "plugins": ["sentence-case"],
+  "release-as": "0.2.1",
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
Holds the version at 0.2.1: with this pin the bot proposes nothing. Remove the line when ready to cut the first automated release (currently would propose 0.3.0). Follow-up to #226, which merged without it.