### PR TITLE
fix: show upload only in side panel

### DIFF
--- a/apogee-extension/ui/app.css
+++ b/apogee-extension/ui/app.css
@@ -379,6 +379,13 @@ body {
   white-space: nowrap;
 }
 
+/* Popup surface shows only Paste text + Select text, centered by .chip-row.
+   Upload lives in the side panel, where the file picker keeps its change
+   event instead of crashing the transient popup. */
+html:not([data-surface="side-panel"]) #uploadFileBtn {
+  display: none;
+}
+
 .dialog-backdrop {
   position: fixed;
   inset: 0;

--- a/apogee-extension/ui/app.js
+++ b/apogee-extension/ui/app.js
@@ -2443,21 +2443,9 @@ async function summarizeFile(file) {
   await summarizeCustomContent(file.name, text.trim());
 }
 
-document
-  .getElementById("uploadFileBtn")
-  ?.addEventListener("click", async () => {
-    if (!isSidePanelSurface) {
-      try {
-        await openSidePanel();
-        closeTransientSurface();
-      } catch (err) {
-        console.error("Could not open side panel for file upload:", err);
-        announce(`Could not open side panel: ${err.message || err}`);
-      }
-      return;
-    }
-    fileUploadInput?.click();
-  });
+document.getElementById("uploadFileBtn")?.addEventListener("click", () => {
+  fileUploadInput?.click();
+});
 
 async function handleFile(file) {
   if (!file) return;


### PR DESCRIPTION
Popup surface shows only Paste + Select text. Upload lives in the side panel where the file picker keeps its change event instead of crashing the transient popup.

- Hides #uploadFileBtn outside [data-surface=side-panel] via CSS
- Simplifies upload click handler to fileUploadInput.click() (only reachable in side panel)