### PR TITLE
docs: surface the browser-free extractor harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Read the full security model in [Privacy and Security Architecture](PRIVACY.md).
 
 ### For Developers & Contributors
 
+**Extractor contributions need no browser, GPU, or model download.** The fixture harness runs site extractors against saved HTML in Node.js 22 or newer:
+
+```bash
+cd apogee-extension
+npm install
+npm test
+```
+
+See the [extractor test harness and worked examples](apogee-extension/tests/extractors/README.md) to add a fixture or test a site-specific extractor. The [contributing guide](CONTRIBUTING.md) lists available issues and the checks to run before a PR.
+
 - **[Architecture Reference](ARCHITECTURE.md)**: Details on the 4 contexts, how it works, execution flows, and trust limits.
 - **[Developer Setup](DEVELOPMENT.md)**: Steps to build, run watch mode, run test suites, and format code.
 - **[Contributing Guide](CONTRIBUTING.md)**: Rules for opening pull requests, sending code changes, and claiming issues.


### PR DESCRIPTION
## Summary

The README now shows that extractor work runs against saved HTML fixtures in Node.js, with no browser, GPU, or model download. It includes the minimal install/test commands and links directly to the harness, worked examples, and contribution rules.

Fixes #238.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` (both `dist/chrome` and `dist/firefox`)
- [ ] Manually exercised the change in a loaded browser extension

Node 24.15.0. The full test suite and lint pass in a fresh Linux test copy. All 86 extractor tests also pass on Windows. The full Windows run has four failures in the unchanged manifest tests, which build paths from URL pathnames; all four pass on Linux. The Windows build was run using the PowerShell equivalent of the two scripts (`$env:TARGET_BROWSER = 'chrome'; npx vite build`, then `firefox`), and both outputs built successfully. Checked README formatting and the two relative link targets. This is a README-only change, so no browser behavior was changed or manually exercised.

## Privacy impact

- [x] No new outbound network calls
- [ ] Adds/changes a network call (described above, docs updated)
- [x] Permissions unchanged, or all four of manifest / README / PRIVACY / store-listing updated together
