### PR TITLE
docs: add troubleshooting guide for common failures (#237)

### DIFF
--- a/ERROR.md
+++ b/ERROR.md
@@ -128,4 +128,6 @@ These should never reach the UI. If one does, it is a bug worth reporting with t
 
 ## Reporting one
 
+If your symptom matches a known failure, the [Troubleshooting](TROUBLESHOOTING.md) page may fix it faster than a report.
+
 Turn on debug logs in Settings, reproduce the failure, then use Copy diagnostics. That copies the browser, provider, model, WebGPU state, and recent log lines plus the raw base error, which is often more exact than the message shown in the popup.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Read the full security model in [Privacy and Security Architecture](PRIVACY.md).
 - **[Translation Reference](TRANSLATION.md)**: Overview of 29 supported target languages and Opus-MT model tiers.
 - **[Privacy Architecture](PRIVACY.md)**: Full details on network limits, storage, and permissions.
 - **[Error Messages Guide](ERROR.md)**: Full list of user-facing messages, causes, fixes, and diagnostics.
+- **[Troubleshooting](TROUBLESHOOTING.md)**: Fix the common failures by symptom: no WebGPU, stalled model download, Ollama unreachable, slow Firefox, unreadable page.
 
 ### For Developers & Contributors
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,59 @@
+# Troubleshooting
+
+Something not working? Find your symptom below. Each section tells you what to check first and where to read next. If you need the exact wording of a popup message, look it up in the [Error Messages Guide](ERROR.md).
+
+If nothing below fits, skip to [Still stuck](#still-stuck).
+
+## WebGPU is unavailable
+
+Apogee's default provider on Chromium browsers (WebLLM) needs WebGPU. If the popup says WebGPU is not supported:
+
+1. Open Settings and switch the provider to In-Browser (Transformers.js). It runs on CPU through WebAssembly and needs no GPU.
+2. If you want WebGPU back, check the [Browser Support](BROWSERS.md) table. On Brave you may need to turn WebGPU on under `brave://flags`. Updating your GPU driver sometimes brings WebGPU back on Chrome.
+3. On Firefox there is no WebLLM at all. Firefox lacks the offscreen-document support WebLLM needs, so Transformers.js is the default there. This is expected, not a bug.
+
+## The model download keeps stalling
+
+The first in-browser run downloads the model, which can be several hundred megabytes. If progress stalls or restarts:
+
+1. Wait and try again. Apogee retries a stalled download on its own (up to four attempts) and keeps the parts it already saved, so a retry resumes instead of starting over.
+2. If every attempt fails, suspect the network path: a VPN, a captive portal, or a strict proxy is the usual cause. Try a plain connection and retry.
+3. If downloads keep failing on your machine, switch to Local Ollama or llama.cpp in Settings. Those run outside the browser and skip the download entirely. See the [Local Ollama Guide](OLLAMA.md) and the [Local llama.cpp Guide](LLAMACPP.md).
+
+## Apogee cannot reach Ollama
+
+If Settings shows the model list as defaults, or summaries fail with a connection error:
+
+1. Check Ollama is running: `ollama serve`. Then check the host in Apogee Settings matches where Ollama listens (default `http://localhost:11434`).
+2. Check you have a model pulled: `ollama list`. If the list is empty, run `ollama pull <model>` (for example `ollama pull llama3.2`).
+3. Apogee only talks to Ollama over plain http on localhost or 127.0.0.1. A remote host is refused on purpose so page text never leaves your machine. To use a remote server, forward its port over ssh (for example `ssh -L 11434:localhost:11434 ...`) and point Apogee at localhost.
+4. The same three rules apply to llama.cpp (`llama-server`, default `http://127.0.0.1:8080`, health check `curl http://127.0.0.1:8080/health`). If the server was started with `--api-key`, the key in Settings must match.
+
+Setup steps per operating system are in the [Local Ollama Guide](OLLAMA.md).
+
+## Firefox is slow
+
+Firefox runs the Transformers.js provider on CPU, so generation speed depends on your processor. If summaries take very long:
+
+1. Use the smallest model that still gives good summaries. SmolLM2 360M (the default, about 270 MB) is the fastest. Larger CPU models suit faster desktop CPUs.
+2. Summarize shorter pages or parts. Long pages are processed in chunks, and each chunk costs CPU time. The Transformers.js context window is capped at 4096 tokens to keep generation fast.
+3. If you have a GPU and want faster local runs, use Chrome or Edge with the WebLLM provider, or run Ollama or llama.cpp outside the browser.
+
+Model sizes and trade-offs are in the [Model Reference](MODELS.md).
+
+## Apogee cannot read the page
+
+If the popup says it cannot read the page or there is nothing to summarize:
+
+1. Some pages are off limits to every extension: browser-internal pages (`chrome://`, `about:`, `edge://`), the Chrome Web Store, and Firefox Add-ons. Move to a normal webpage. Nothing is broken.
+2. Reload the tab, wait for it to finish loading, then summarize again. The most common cause of an empty result is Apogee reading the page before it finished rendering.
+3. For YouTube, check the video has captions. Apogee reads the transcript, not the audio.
+4. For a PDF that fails to load, download the file and open it from disk (a `file://` URL) with file access turned on for the extension. If the PDF holds no text layer (a scan or image export), Apogee cannot read it. Run it through an OCR tool first.
+5. For a blank tab, an empty inbox view, or a page drawn fully in images or canvas, there is no text to summarize. Open a real article, email, or video instead.
+
+## Still stuck
+
+1. Turn on debug logs in Settings.
+2. Reproduce the failure.
+3. Use Copy diagnostics in the popup. That copies the browser, provider, model, WebGPU state, and recent log lines plus the raw base error, which is often more exact than the message shown in the popup.
+4. Paste that block into your bug report.

--- a/llms.txt
+++ b/llms.txt
@@ -69,6 +69,7 @@ Content
 - [Translation Reference](TRANSLATION.md): 32-language matrix and Opus-MT model tiers.
 - [Privacy Policy](PRIVACY.md): Detailed privacy, network connections, and permission sandboxing.
 - [Error Messages Guide](ERROR.md): Complete catalog of user-facing messages, cause breakdowns, and diagnostic steps.
+- [Troubleshooting](TROUBLESHOOTING.md): Common failures by symptom, with fixes and links to the guides above.
 - [Developer Setup](DEVELOPMENT.md): Build environment, scripts, test suite, and contributing guidelines.
 - [Contributing](./CONTRIBUTING.md): Development setup, PR rules, and issue claiming guidelines.
 - [Roadmap](./ROADMAP.md): Project goals, completed releases, and planned feature roadmap.


### PR DESCRIPTION
## Summary

Fixes #237. New TROUBLESHOOTING.md collects the known failure modes into one symptom-first page: no WebGPU, stalled model download, Ollama unreachable, slow Firefox on CPU, unreadable page, plus a diagnostics fallback. Every fix links to the existing guides (ERROR.md, OLLAMA.md, LLAMACPP.md, MODELS.md, BROWSERS.md); no new facts introduced. Linked from README Documentation Directory and llms.txt sitemap, with a backlink from ERROR.md Reporting section.

## Test plan

- [x] `npx prettier --check` on all touched md files
- [x] `cspell lint` on all touched md files (only hit is pre-existing `nvmrc` in llms.txt, present on clean HEAD)
- [x] Verified all relative links resolve to existing files
- [ ] `npm test` (docs-only change, no code touched)
- [ ] `npm run build` (docs-only change)

## Privacy impact

- [x] No new outbound network calls
- [x] Permissions unchanged