### PR TITLE
Remove the silent-return hazard in background summarize (#253)

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -829,12 +829,9 @@ async function runBackgroundSummarize(
 
   const selection = normalizeSelectedText(selectionText);
   if (selection && !isSummarizableSelection(selection)) {
-    if (notifyOnFinish) {
-      notifyNothingToSummarize(
-        `Select at least ${MIN_SELECTION_LENGTH} characters to summarize.`,
-      );
-    }
-    return;
+    throw new UserFacingError(
+      `Select at least ${MIN_SELECTION_LENGTH} characters to summarize.`,
+    );
   }
   const isSelection = selection.length > 0;
 
@@ -850,16 +847,10 @@ async function runBackgroundSummarize(
   } else {
     pageData = await extractFromActiveTab(tab);
     if (!pageData) {
-      if (notifyOnFinish) {
-        notifyNothingToSummarize(COULD_NOT_READ_THIS_PAGE_ERROR_MSG);
-      }
-      return;
+      throw new UserFacingError(COULD_NOT_READ_THIS_PAGE_ERROR_MSG);
     }
     if (!pageData.isPdf && !pageData.content) {
-      if (notifyOnFinish) {
-        notifyNothingToSummarize(NOTHING_TO_SUMMARIZE_ERROR_MSG);
-      }
-      return;
+      throw new UserFacingError(NOTHING_TO_SUMMARIZE_ERROR_MSG);
     }
   }
 
@@ -889,20 +880,14 @@ async function runBackgroundSummarize(
     } catch (err) {
       const msg = err?.message || String(err);
       if (msg.startsWith("PDF_TOO_LARGE:")) {
-        if (notifyOnFinish) {
-          notifyNothingToSummarize(
-            "This PDF is too large to process inside the extension. Try a shorter document.",
-          );
-        }
-        return;
+        throw new UserFacingError(
+          "This PDF is too large to process inside the extension. Try a shorter document.",
+        );
       }
       throw err;
     }
     if (!content) {
-      if (notifyOnFinish) {
-        notifyNothingToSummarize(COULD_NOT_EXTRACT_TEXT_FROM_PDF_ERROR_MSG);
-      }
-      return;
+      throw new UserFacingError(COULD_NOT_EXTRACT_TEXT_FROM_PDF_ERROR_MSG);
     }
   }
 
@@ -1420,18 +1405,6 @@ function notifyJobComplete({ title, tabId, windowId }) {
     iconUrl: chrome.runtime.getURL("assets/icon-96.png"),
     title: "Summary ready",
     message: title ? `"${title}" is ready to view.` : "Click to view it.",
-  });
-}
-
-function notifyNothingToSummarize(message) {
-  if (typeof chrome.notifications === "undefined") return;
-  const notificationId = `apogee-summary-empty-${crypto.randomUUID()}`;
-  notificationTargets.set(notificationId, { helpUrl: errorHelpUrl(message) });
-  chrome.notifications.create(notificationId, {
-    type: "basic",
-    iconUrl: chrome.runtime.getURL("assets/icon-96.png"),
-    title: "Nothing to summarize",
-    message: `${message} Click to see what this means.`,
   });
 }
 

--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -819,7 +819,7 @@ async function generateTransformersSuggestions(
   });
 }
 
-async function runBackgroundSummarize(
+export async function runBackgroundSummarize(
   tab,
   { notifyOnFinish, selectionText } = {},
 ) {

--- a/apogee-extension/tests/background/runBackgroundSummarize.test.js
+++ b/apogee-extension/tests/background/runBackgroundSummarize.test.js
@@ -34,3 +34,66 @@ test("runBackgroundSummarize only calls startLocalHttpStream once for Local Olla
     "streamId init block should not call startLocalHttpStream before registerStreamJob",
   );
 });
+
+test("runBackgroundSummarize throws UserFacingError for empty-content cases instead of silently returning (#253)", () => {
+  const swCode = fs.readFileSync(
+    new URL("../../background/service-worker.js", import.meta.url),
+    "utf-8",
+  );
+
+  const fnMatch = swCode.match(
+    /async function runBackgroundSummarize[\s\S]*?\n\}/,
+  );
+  assert.ok(fnMatch, "runBackgroundSummarize function found");
+  const fnBody = fnMatch[0];
+
+  // Every empty-content guard now throws a UserFacingError so the caller's
+  // .catch(notifyJobFailed) surfaces it, instead of returning undefined and
+  // leaving the waiter hanging.
+  const throwCount = (fnBody.match(/throw new UserFacingError\(/g) || [])
+    .length;
+  assert.ok(
+    throwCount >= 5,
+    `expected >= 5 'throw new UserFacingError(...)' guards, found ${throwCount}`,
+  );
+
+  // The old silent-return pattern must be gone.
+  assert.ok(
+    !fnBody.includes("notifyNothingToSummarize"),
+    "notifyNothingToSummarize should no longer be called",
+  );
+  assert.ok(
+    !/if \(notifyOnFinish\)/.test(fnBody),
+    "no `if (notifyOnFinish)` empty-content guard should remain",
+  );
+});
+
+test("runBackgroundSummarize still threads notifyOnFinish for the success notification (#253)", () => {
+  const swCode = fs.readFileSync(
+    new URL("../../background/service-worker.js", import.meta.url),
+    "utf-8",
+  );
+
+  const fnMatch = swCode.match(
+    /async function runBackgroundSummarize[\s\S]*?\n\}/,
+  );
+  assert.ok(fnMatch, "runBackgroundSummarize function found");
+  const fnBody = fnMatch[0];
+
+  // notifyOnFinish is still accepted and passed into the finalize object so the
+  // success-path completion notification keeps working.
+  assert.ok(
+    fnBody.includes("{ notifyOnFinish, selectionText } = {}"),
+    "runBackgroundSummarize should still accept notifyOnFinish",
+  );
+  assert.ok(
+    /\n\s*notifyOnFinish,\n/.test(fnBody),
+    "notifyOnFinish should still be threaded into the finalize object",
+  );
+
+  // The orphaned helper should be removed from the module entirely.
+  assert.ok(
+    !swCode.includes("function notifyNothingToSummarize"),
+    "the orphaned notifyNothingToSummarize helper should be removed",
+  );
+});

--- a/apogee-extension/tests/background/runBackgroundSummarize.test.js
+++ b/apogee-extension/tests/background/runBackgroundSummarize.test.js
@@ -52,12 +52,22 @@ test("runBackgroundSummarize only calls startLocalHttpStream once for Local Olla
 // Each branch now throws a UserFacingError so the call site's
 // `.catch(notifyJobFailed)` presents it.
 
+// `node --test` runs each test file in its own process, so this module-scope
+// `globalThis.chrome` cannot leak into other files (same pattern as
+// sponsorBlockGate.test.js). It is not torn down between tests here because
+// runBackgroundSummarize kicks off fire-and-forget work (audit logging,
+// follow-up question generation) that would throw if `chrome` disappeared.
 const { chrome } = createExtensionApiMock({ settings: {} });
 chrome.scripting = {
-  // Version check short-circuits (matches getManifest().version) so no content
-  // scripts are injected; for the PDF path this same stub returns a truthy
-  // "base64" blob so extractPdfContent proceeds to the extract-pdf message.
-  executeScript: async () => [{ result: "0.2.1" }],
+  executeScript: async ({ func }) => {
+    // The extractor-version probe must match getManifest().version so no
+    // content scripts are injected; the PDF-download script returns a base64
+    // blob so extractPdfContent proceeds to the extract-pdf message.
+    if (String(func).includes("__apogeeExtractorVersion")) {
+      return [{ result: "0.2.1" }];
+    }
+    return [{ result: "JVBERi0xLjQK" }]; // "%PDF-1.4\n" base64
+  },
 };
 globalThis.chrome = chrome;
 

--- a/apogee-extension/tests/background/runBackgroundSummarize.test.js
+++ b/apogee-extension/tests/background/runBackgroundSummarize.test.js
@@ -64,7 +64,7 @@ chrome.scripting = {
     // content scripts are injected; the PDF-download script returns a base64
     // blob so extractPdfContent proceeds to the extract-pdf message.
     if (String(func).includes("__apogeeExtractorVersion")) {
-      return [{ result: "0.2.1" }];
+      return [{ result: chrome.runtime.getManifest().version }];
     }
     return [{ result: "JVBERi0xLjQK" }]; // "%PDF-1.4\n" base64
   },

--- a/apogee-extension/tests/background/runBackgroundSummarize.test.js
+++ b/apogee-extension/tests/background/runBackgroundSummarize.test.js
@@ -1,6 +1,14 @@
 import test from "node:test";
 import assert from "node:assert";
 import fs from "node:fs";
+import { createExtensionApiMock } from "../helpers/extensionApiMock.js";
+import { UserFacingError } from "../../lib/util/userError.js";
+import {
+  COULD_NOT_READ_THIS_PAGE_ERROR_MSG,
+  NOTHING_TO_SUMMARIZE_ERROR_MSG,
+  COULD_NOT_EXTRACT_TEXT_FROM_PDF_ERROR_MSG,
+} from "../../lib/util/messages.js";
+import { MIN_SELECTION_LENGTH } from "../../lib/extract/selection.js";
 
 test("runBackgroundSummarize only calls startLocalHttpStream once for Local Ollama (#151)", async () => {
   const swCode = fs.readFileSync(
@@ -35,65 +43,148 @@ test("runBackgroundSummarize only calls startLocalHttpStream once for Local Olla
   );
 });
 
-test("runBackgroundSummarize throws UserFacingError for empty-content cases instead of silently returning (#253)", () => {
-  const swCode = fs.readFileSync(
-    new URL("../../background/service-worker.js", import.meta.url),
-    "utf-8",
-  );
+// --- #253: the empty-content branches must throw, not silently return ---
+//
+// runBackgroundSummarize used to guard its "nothing to summarize" notifications
+// behind `if (notifyOnFinish)` and then `return` with no value. If a caller ever
+// passed `notifyOnFinish: false`, the job would resolve to `undefined` and
+// whatever awaited it would hang forever with no error and no notification.
+// Each branch now throws a UserFacingError so the call site's
+// `.catch(notifyJobFailed)` presents it.
 
-  const fnMatch = swCode.match(
-    /async function runBackgroundSummarize[\s\S]*?\n\}/,
-  );
-  assert.ok(fnMatch, "runBackgroundSummarize function found");
-  const fnBody = fnMatch[0];
+const { chrome } = createExtensionApiMock({ settings: {} });
+chrome.scripting = {
+  // Version check short-circuits (matches getManifest().version) so no content
+  // scripts are injected; for the PDF path this same stub returns a truthy
+  // "base64" blob so extractPdfContent proceeds to the extract-pdf message.
+  executeScript: async () => [{ result: "0.2.1" }],
+};
+globalThis.chrome = chrome;
 
-  // Every empty-content guard now throws a UserFacingError so the caller's
-  // .catch(notifyJobFailed) surfaces it, instead of returning undefined and
-  // leaving the waiter hanging.
-  const throwCount = (fnBody.match(/throw new UserFacingError\(/g) || [])
-    .length;
-  assert.ok(
-    throwCount >= 5,
-    `expected >= 5 'throw new UserFacingError(...)' guards, found ${throwCount}`,
-  );
+const { runBackgroundSummarize } =
+  await import("../../background/service-worker.js");
 
-  // The old silent-return pattern must be gone.
+const TAB = {
+  id: 101,
+  url: "https://example.com/article",
+  title: "Example Article",
+  windowId: 1,
+};
+
+async function rejectsUserFacing(fn, expectedMessage, label) {
+  let thrown;
+  try {
+    await fn();
+  } catch (err) {
+    thrown = err;
+  }
   assert.ok(
-    !fnBody.includes("notifyNothingToSummarize"),
-    "notifyNothingToSummarize should no longer be called",
+    thrown !== undefined,
+    `${label}: expected a throw, but the call resolved (the silent-return hazard)`,
   );
   assert.ok(
-    !/if \(notifyOnFinish\)/.test(fnBody),
-    "no `if (notifyOnFinish)` empty-content guard should remain",
+    thrown instanceof UserFacingError,
+    `${label}: expected a UserFacingError, got ${thrown && thrown.constructor.name}`,
+  );
+  if (expectedMessage) {
+    assert.strictEqual(thrown.message, expectedMessage, `${label}: message`);
+  }
+}
+
+test("runBackgroundSummarize throws on a too-short selection instead of returning undefined (#253)", async () => {
+  await rejectsUserFacing(
+    () =>
+      runBackgroundSummarize(TAB, {
+        notifyOnFinish: false,
+        selectionText: "too short",
+      }),
+    `Select at least ${MIN_SELECTION_LENGTH} characters to summarize.`,
+    "too-short selection",
   );
 });
 
-test("runBackgroundSummarize still threads notifyOnFinish for the success notification (#253)", () => {
+test("runBackgroundSummarize throws when the active tab yields no page data (#253)", async () => {
+  const original = chrome.tabs.sendMessage;
+  chrome.tabs.sendMessage = async () => null;
+  try {
+    await rejectsUserFacing(
+      () => runBackgroundSummarize(TAB, { notifyOnFinish: false }),
+      COULD_NOT_READ_THIS_PAGE_ERROR_MSG,
+      "no page data",
+    );
+  } finally {
+    chrome.tabs.sendMessage = original;
+  }
+});
+
+test("runBackgroundSummarize throws when the page has no extractable content (#253)", async () => {
+  const original = chrome.tabs.sendMessage;
+  chrome.tabs.sendMessage = async () => ({ isPdf: false, content: "" });
+  try {
+    await rejectsUserFacing(
+      () => runBackgroundSummarize(TAB, { notifyOnFinish: false }),
+      NOTHING_TO_SUMMARIZE_ERROR_MSG,
+      "empty page content",
+    );
+  } finally {
+    chrome.tabs.sendMessage = original;
+  }
+});
+
+test("runBackgroundSummarize throws when a PDF is too large to process (#253)", async () => {
+  const originalSend = chrome.tabs.sendMessage;
+  const originalRuntimeSend = chrome.runtime.sendMessage;
+  chrome.tabs.sendMessage = async () => ({
+    isPdf: true,
+    content: "",
+    title: "Big PDF",
+    url: TAB.url,
+  });
+  chrome.runtime.sendMessage = async () => ({
+    error:
+      "PDF_TOO_LARGE: This PDF is 99 MB, which exceeds the 20 MB limit for in-extension processing.",
+  });
+  try {
+    await rejectsUserFacing(
+      () => runBackgroundSummarize(TAB, { notifyOnFinish: false }),
+      "This PDF is too large to process inside the extension. Try a shorter document.",
+      "PDF too large",
+    );
+  } finally {
+    chrome.tabs.sendMessage = originalSend;
+    chrome.runtime.sendMessage = originalRuntimeSend;
+  }
+});
+
+test("runBackgroundSummarize throws when no text can be extracted from a PDF (#253)", async () => {
+  const originalSend = chrome.tabs.sendMessage;
+  const originalRuntimeSend = chrome.runtime.sendMessage;
+  chrome.tabs.sendMessage = async () => ({
+    isPdf: true,
+    content: "",
+    title: "Scanned PDF",
+    url: TAB.url,
+  });
+  chrome.runtime.sendMessage = async () => ({ text: "" });
+  try {
+    await rejectsUserFacing(
+      () => runBackgroundSummarize(TAB, { notifyOnFinish: false }),
+      COULD_NOT_EXTRACT_TEXT_FROM_PDF_ERROR_MSG,
+      "empty PDF text",
+    );
+  } finally {
+    chrome.tabs.sendMessage = originalSend;
+    chrome.runtime.sendMessage = originalRuntimeSend;
+  }
+});
+
+test("the orphaned notifyNothingToSummarize helper is gone (#253)", () => {
   const swCode = fs.readFileSync(
     new URL("../../background/service-worker.js", import.meta.url),
     "utf-8",
   );
-
-  const fnMatch = swCode.match(
-    /async function runBackgroundSummarize[\s\S]*?\n\}/,
-  );
-  assert.ok(fnMatch, "runBackgroundSummarize function found");
-  const fnBody = fnMatch[0];
-
-  // notifyOnFinish is still accepted and passed into the finalize object so the
-  // success-path completion notification keeps working.
   assert.ok(
-    fnBody.includes("{ notifyOnFinish, selectionText } = {}"),
-    "runBackgroundSummarize should still accept notifyOnFinish",
-  );
-  assert.ok(
-    /\n\s*notifyOnFinish,\n/.test(fnBody),
-    "notifyOnFinish should still be threaded into the finalize object",
-  );
-
-  // The orphaned helper should be removed from the module entirely.
-  assert.ok(
-    !swCode.includes("function notifyNothingToSummarize"),
-    "the orphaned notifyNothingToSummarize helper should be removed",
+    !swCode.includes("notifyNothingToSummarize"),
+    "notifyNothingToSummarize should be removed entirely now that every empty-content branch throws",
   );
 });


### PR DESCRIPTION
Closes #253

Problem: the five empty-content guards in `runBackgroundSummarize` did `if (notifyOnFinish) { notify... } return;`. Every caller passes `notifyOnFinish: true`, so the branches are dead, but a caller passing `false` would make the job resolve to `undefined` and leave its awaiter hanging with no error and no notification.

Fix: each guard now throws a `UserFacingError` (short selection, unreadable page, empty page, PDF too large, no PDF text). The `.catch(notifyJobFailed)` already on every call site catches it, so the message text a user sees is the same. It now appears under the "Summarize failed" notification instead of the dedicated "Nothing to summarize" one, which is the routing the issue asked for. Removed the now-orphaned `notifyNothingToSummarize` helper.

Kept the `notifyOnFinish` parameter since it still gates the success-path `notifyJobComplete` call, as we discussed on the issue.

Two commits (plus a review-fix commit):

1. `fix(background):` the fix, with tests that scan the function source to check each branch throws.
2. `test(background):` swaps those for runtime tests. Exports `runBackgroundSummarize`, calls it once per branch with a mocked extension API, and asserts each rejects with a `UserFacingError` instead of resolving to `undefined`.

Commit 1 is a complete fix on its own. Commit 2 makes the tests stronger but adds an `export` and about 140 lines of mocked-API test. Happy to drop it if you prefer the simpler version.

`npm test`: 566/566 pass. Lint and Prettier clean.
