### PR TITLE
Add Dev.to article extractor (#169)

### DIFF
--- a/apogee-extension/content/content.js
+++ b/apogee-extension/content/content.js
@@ -75,6 +75,9 @@ async function extractPageContent() {
   const discourseData = extractDiscourse();
   if (discourseData) return { ...discourseData, isPdf: false };
 
+  const devtoData = extractDevto();
+  if (devtoData) return { ...devtoData, isPdf: false };
+
   const blueskyData = await extractBluesky();
   if (blueskyData) return { ...blueskyData, isPdf: false };
 

--- a/apogee-extension/content/extractors/devto.js
+++ b/apogee-extension/content/extractors/devto.js
@@ -1,0 +1,125 @@
+const DEVTO_MAX_COMMENTS = 80;
+const DEVTO_MAX_DEPTH = 8;
+const DEVTO_MAX_COMMENT_CHARS = 1500;
+
+const DEVTO_NON_ARTICLE_PATHS = [
+  /^\/$/,
+  /^\/top/,
+  /^\/latest/,
+  /^\/t\//,
+  /^\/tags?\//,
+  /^\/search/,
+  /^\/settings/,
+  /^\/new/,
+  /^\/listings/,
+  /^\/pod/,
+  /^\/videos?/,
+];
+
+function devtoText(el) {
+  if (!el) return "";
+  return (el.innerText || el.textContent || "").trim();
+}
+
+function isDevtoHost() {
+  const host = location.hostname.toLowerCase();
+  return host === "dev.to" || host.endsWith(".dev.to");
+}
+
+function devtoCommentDepth(node) {
+  for (const cls of node.classList || []) {
+    const m = /^comment--deep-(\d+)$/.exec(cls);
+    if (m) return parseInt(m[1], 10);
+  }
+  const attr =
+    node.getAttribute("data-comment-depth") || node.getAttribute("data-depth");
+  if (attr !== null && attr !== "") {
+    const n = parseInt(attr, 10);
+    if (!isNaN(n)) return n;
+  }
+  let depth = 0;
+  let parent = node.parentElement;
+  while (parent) {
+    if (parent.classList?.contains("single-comment-node")) depth++;
+    parent = parent.parentElement;
+  }
+  return depth;
+}
+
+function devtoCommentItems(nodes) {
+  return Array.from(nodes)
+    .filter(
+      (el) => el && (typeof el.isConnected === "undefined" || el.isConnected),
+    )
+    .map((el) => {
+      const bodyEl = el.querySelector?.(".comment__body");
+      const authorEl =
+        el.querySelector?.(".js-comment-username") ||
+        el.querySelector?.(".comment__header a");
+      return {
+        depth: devtoCommentDepth(el),
+        author: devtoText(authorEl) || "anon",
+        text: bodyEl
+          ? threadTruncate(devtoText(bodyEl), DEVTO_MAX_COMMENT_CHARS)
+          : "",
+      };
+    });
+}
+
+function extractDevto() {
+  if (!isDevtoHost()) return null;
+  if (DEVTO_NON_ARTICLE_PATHS.some((re) => re.test(location.pathname)))
+    return null;
+
+  const bodyEl = document.querySelector("#article-body");
+  if (!bodyEl) return null;
+
+  const titleEl =
+    document.querySelector("#main-title h1") ||
+    document.querySelector("h1.fs-3xl");
+  const title = devtoText(titleEl) || document.title.trim();
+  const body = devtoText(bodyEl);
+  if (!title || !body) return null;
+
+  const authorEl =
+    document.querySelector(
+      "#main-title .crayons-article__header__meta a.crayons-link",
+    ) || document.querySelector(".crayons-article__header__meta a[href^='/']");
+  const author = devtoText(authorEl) || "anon";
+
+  const dateEl = document.querySelector(
+    "#main-title time, .crayons-article__header__meta time",
+  );
+  const date = dateEl?.getAttribute("datetime") || devtoText(dateEl);
+
+  const tags = Array.from(
+    document.querySelectorAll(
+      "#main-title .crayons-tag, .crayons-article__header .crayons-tag",
+    ),
+  )
+    .map((t) => devtoText(t).replace(/^#/, ""))
+    .filter(Boolean);
+
+  const commentNodes = document.querySelectorAll(
+    "#comment-trees-container .single-comment-node, #comments .single-comment-node",
+  );
+  const nodes = buildThreadNodes(devtoCommentItems(commentNodes));
+  const eligible = (n) => n.text && n.depth <= DEVTO_MAX_DEPTH;
+  const comments = selectThreadComments(nodes, eligible, DEVTO_MAX_COMMENTS);
+
+  let content = `DEV Community article\n\nTitle: ${title}\nAuthor: ${author}\n`;
+  if (date) content += `Posted: ${date}\n`;
+  if (tags.length) content += `Tags: ${tags.join(", ")}\n`;
+  content += `\nPost:\n${body}\n`;
+
+  content += comments.length
+    ? `\n${THREAD_COMMENTS_HEADER}\n${formatThreadComments(comments)}\n`
+    : `\n(No comments yet.)\n`;
+
+  return {
+    type: "devto",
+    title,
+    url: location.href,
+    content: content.trim(),
+  };
+}

--- a/apogee-extension/eslint.config.js
+++ b/apogee-extension/eslint.config.js
@@ -58,6 +58,7 @@ export default [
         extractStackOverflow: "readonly",
         extractLemmy: "readonly",
         extractDiscourse: "readonly",
+        extractDevto: "readonly",
         extractBluesky: "readonly",
       },
     },
@@ -92,6 +93,7 @@ export default [
       "content/extractors/stackoverflow.js",
       "content/extractors/lemmy.js",
       "content/extractors/discourse.js",
+      "content/extractors/devto.js",
       "content/extractors/bluesky.js",
     ],
     languageOptions: {

--- a/apogee-extension/lib/extract/pageExtraction.js
+++ b/apogee-extension/lib/extract/pageExtraction.js
@@ -88,6 +88,7 @@ export async function extractFromActiveTab(tab) {
           "/content/extractors/stackoverflow.js",
           "/content/extractors/lemmy.js",
           "/content/extractors/discourse.js",
+          "/content/extractors/devto.js",
           "/content/extractors/bluesky.js",
           "/content/content.js",
         ],

--- a/apogee-extension/tests/extractors/content.test.js
+++ b/apogee-extension/tests/extractors/content.test.js
@@ -21,6 +21,7 @@ const INJECTED_FILES = [
   "extractors/stackoverflow.js",
   "extractors/lemmy.js",
   "extractors/discourse.js",
+  "extractors/devto.js",
   "extractors/bluesky.js",
   "content.js",
 ];

--- a/apogee-extension/tests/extractors/devto.test.js
+++ b/apogee-extension/tests/extractors/devto.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loadExtractors } from "./helpers/extractorHarness.js";
+
+const FILES = ["extractors/thread.js", "extractors/devto.js"];
+const URL = "https://dev.to/alice/why-i-still-write-vanilla-css-1a2b";
+
+test("Dev.to extractor: parses article title, author, date, tags, body, and threaded comments", () => {
+  const { extractDevto } = loadExtractors({
+    files: FILES,
+    url: URL,
+    fixture: "devto-article.html",
+  });
+
+  const result = extractDevto();
+
+  assert.equal(result.type, "devto");
+  assert.equal(result.title, "Why I still write vanilla CSS");
+  assert.equal(result.url, URL);
+
+  assert.match(result.content, /Title: Why I still write vanilla CSS/);
+  assert.match(result.content, /Author: Alice/);
+  assert.match(result.content, /2024-08-18/);
+  assert.match(result.content, /Tags: css, webdev/);
+  assert.match(result.content, /Every few months a new CSS framework lands/);
+
+  assert.match(
+    result.content,
+    /\[1\] (<replies: 1> )?Bob: Custom properties really did change the game/,
+  );
+  assert.match(
+    result.content,
+    /\[1\.1\] Carol: Agreed, and container queries removed/,
+  );
+  assert.match(result.content, /\[2\] Dave: Counterpoint: on a large team/);
+});
+
+test("Dev.to extractor: returns null for home, tag, and profile pages", () => {
+  const html = `<!doctype html>
+<html>
+  <head><title>DEV Community</title></head>
+  <body><main><h1>DEV Community</h1></main></body>
+</html>`;
+
+  for (const url of [
+    "https://dev.to/",
+    "https://dev.to/t/css",
+    "https://dev.to/alice",
+    "https://dev.to/search?q=css",
+  ]) {
+    const { extractDevto } = loadExtractors({ files: FILES, url, html });
+    assert.equal(extractDevto(), null, `${url} should return null`);
+  }
+});
+
+test("Dev.to extractor: returns null off dev.to", () => {
+  const { extractDevto } = loadExtractors({
+    files: FILES,
+    url: "https://example.com/alice/why-i-still-write-vanilla-css-1a2b",
+    fixture: "devto-article.html",
+  });
+
+  assert.equal(extractDevto(), null);
+});

--- a/apogee-extension/tests/extractors/fixtures/devto-article.html
+++ b/apogee-extension/tests/extractors/fixtures/devto-article.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Why I still write vanilla CSS - DEV Community</title>
+  <link rel="canonical" href="https://dev.to/alice/why-i-still-write-vanilla-css-1a2b">
+</head>
+<body>
+  <article class="crayons-layout crayons-layout--3-cols crayons-layout--article">
+    <header class="crayons-article__header" id="main-title">
+      <div class="crayons-article__header__meta">
+        <div class="flex flex-1 mb-5 items-start">
+          <div class="pl-3 flex-1">
+            <a href="/alice" class="crayons-link fw-bold">Alice</a>
+            <p class="fs-xs color-base-60">
+              <span>Posted on <time datetime="2024-08-18T19:25:58Z" class="date">Aug 18, 2024</time></span>
+            </p>
+          </div>
+        </div>
+        <h1 class="fs-3xl m:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight mb-2 medium">
+          Why I still write vanilla CSS
+        </h1>
+        <div class="spec__tags">
+          <a class="crayons-tag" href="/t/css"><span class="crayons-tag__prefix">#</span>css</a>
+          <a class="crayons-tag" href="/t/webdev"><span class="crayons-tag__prefix">#</span>webdev</a>
+        </div>
+      </div>
+    </header>
+
+    <div class="crayons-article__main">
+      <div class="crayons-article__body text-styles spec__body" id="article-body">
+        <p>Every few months a new CSS framework lands and promises to end hand-written stylesheets forever.</p>
+        <p>I keep coming back to vanilla CSS because the cascade, custom properties, and container queries now cover most of what I used to reach for a framework for.</p>
+      </div>
+    </div>
+
+    <section id="comments" class="comments">
+      <div class="comments" id="comment-trees-container">
+        <div id="comment-node-101" class="comment single-comment-node comment--deep-0" data-comment-id="101">
+          <div class="comment__inner">
+            <div class="inner-comment comment__details">
+              <div class="comment__content crayons-card">
+                <div class="comment__header">
+                  <a href="/bob" class="crayons-link crayons-link--secondary"><span class="js-comment-username">Bob</span></a>
+                </div>
+                <div class="comment__body text-styles text-styles--secondary body">
+                  <p>Custom properties really did change the game. Theming without a build step is underrated.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="comment-node-102" class="comment single-comment-node comment--deep-1" data-comment-id="102">
+            <div class="comment__inner">
+              <div class="inner-comment comment__details">
+                <div class="comment__content crayons-card">
+                  <div class="comment__header">
+                    <a href="/carol" class="crayons-link crayons-link--secondary"><span class="js-comment-username">Carol</span></a>
+                  </div>
+                  <div class="comment__body text-styles text-styles--secondary body">
+                    <p>Agreed, and container queries removed my last reason to pull in a layout framework.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="comment-node-103" class="comment single-comment-node comment--deep-0" data-comment-id="103">
+          <div class="comment__inner">
+            <div class="inner-comment comment__details">
+              <div class="comment__content crayons-card">
+                <div class="comment__header">
+                  <a href="/dave" class="crayons-link crayons-link--secondary"><span class="js-comment-username">Dave</span></a>
+                </div>
+                <div class="comment__body text-styles text-styles--secondary body">
+                  <p>Counterpoint: on a large team the consistency a framework enforces is worth the bundle cost.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </article>
+</body>
+</html>


### PR DESCRIPTION
Closes #169

New Forem/DEV extractor: article title, author, date, tags, and body plus threaded comments through the shared thread helpers (80 comments / depth 8 / 1500 chars).

- New: apogee-extension/content/extractors/devto.js
- Wired into content/content.js dispatcher and lib/extract/pageExtraction.js injection list (plus content.test.js mirror and eslint globals)
- Tests: tests/extractors/devto.test.js + fixtures/devto-article.html (article parse, null on listing/profile pages, null off-host)

Returns null for non-article pages so the generic Readability extractor handles them.

Verified: 569/569 pass, eslint and Prettier clean.