### PR TITLE
Accessibility pass on the landing page (#240)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <a class="skip" href="#content">Skip to content</a>
     <main id="top" class="frame">
       <div class="rules" aria-hidden="true"><i></i><i></i><i></i><i></i></div>
 
@@ -29,14 +30,14 @@
         </div>
       </header>
 
-      <section class="hero">
+      <section class="hero" id="content">
         <div class="hero-rules" aria-hidden="true"><i></i><i></i><i></i><i></i></div>
         <div class="wrap hero-grid">
           <div class="hero-head">
             <h1 data-split>Summarize anything. On your own machine.</h1>
           </div>
           <div class="hero-side reveal">
-            <img class="hero-mark" src="assets/orb.png" alt="apogee" />
+            <img class="hero-mark" src="assets/orb.png" alt="" />
             <p class="lead">
               apogee is a browser extension that summarizes articles, videos,
               PDFs, and long email threads entirely on your device. The model
@@ -50,10 +51,10 @@
               </a>
               <div class="hero-btns">
                 <a class="btn btn-fill" href="https://addons.mozilla.org/en-US/firefox/addon/apogeeext/" target="_blank" rel="noopener">
-                  Add to Firefox <span class="arw">&#8599;</span>
+                  Add to Firefox <span class="arw" aria-hidden="true">&#8599;</span>
                 </a>
                 <a class="btn btn-out" href="https://chromewebstore.google.com/detail/apogee/pgemlpomhkdcjjjcpnjlebalnfglomog" target="_blank" rel="noopener">
-                  Add to Chrome <span class="arw">&#8599;</span>
+                  Add to Chrome <span class="arw" aria-hidden="true">&#8599;</span>
                 </a>
               </div>
             </div>
@@ -109,10 +110,10 @@
         </div>
       </section>
 
-      <section id="features" class="fcards">
+      <section id="features" class="fcards" aria-label="Features">
         <div class="wrap fcards-inner">
           <article class="fcard reveal">
-            <img class="fcard-ill" src="assets/card-1-any-page.svg" alt="Illustration of a browser window between two gears" />
+            <img class="fcard-ill" src="assets/card-1-any-page.svg" alt="" />
             <div class="fcard-title"><h3>One Click,<br />Any Page</h3></div>
             <div class="fcard-desc">
               <p>
@@ -123,7 +124,7 @@
           </article>
 
           <article class="fcard reveal">
-            <img class="fcard-ill" src="assets/card-2-hardware.svg" alt="Illustration of a processor chip" />
+            <img class="fcard-ill" src="assets/card-2-hardware.svg" alt="" />
             <div class="fcard-title"><h3>Your Hardware,<br />Your Choice</h3></div>
             <div class="fcard-desc">
               <p>
@@ -134,7 +135,7 @@
           </article>
 
           <article class="fcard reveal">
-            <img class="fcard-ill" src="assets/card-3-private.svg" alt="Illustration of a stack of shields with a padlock" />
+            <img class="fcard-ill" src="assets/card-3-private.svg" alt="" />
             <div class="fcard-title"><h3>Nothing Leaves<br />Your Machine</h3></div>
             <div class="fcard-desc">
               <p>
@@ -145,7 +146,7 @@
           </article>
 
           <article class="fcard reveal">
-            <img class="fcard-ill" src="assets/card-4-grounded.svg" alt="Illustration of a page under a magnifier" />
+            <img class="fcard-ill" src="assets/card-4-grounded.svg" alt="" />
             <div class="fcard-title"><h3>Answers Grounded<br />in the Page</h3></div>
             <div class="fcard-desc">
               <p>
@@ -156,7 +157,7 @@
           </article>
 
           <article class="fcard reveal">
-            <img class="fcard-ill" src="assets/card-5-video.svg" alt="Illustration of a video screen above a chapter timeline" />
+            <img class="fcard-ill" src="assets/card-5-video.svg" alt="" />
             <div class="fcard-title"><h3>Videos, Down<br />to the Minute</h3></div>
             <div class="fcard-desc">
               <p>
@@ -167,7 +168,7 @@
           </article>
 
           <article class="fcard reveal">
-            <img class="fcard-ill" src="assets/card-6-language.svg" alt="Illustration of a globe with a speech bubble" />
+            <img class="fcard-ill" src="assets/card-6-language.svg" alt="" />
             <div class="fcard-title"><h3>Read It in<br />Your Language</h3></div>
             <div class="fcard-desc">
               <p>
@@ -178,7 +179,7 @@
           </article>
 
           <article class="fcard reveal">
-            <img class="fcard-ill" src="assets/card-7-shape.svg" alt="Illustration of a panel of sliders" />
+            <img class="fcard-ill" src="assets/card-7-shape.svg" alt="" />
             <div class="fcard-title"><h3>Shaped to<br />Your Taste</h3></div>
             <div class="fcard-desc">
               <p>
@@ -196,10 +197,10 @@
           <h2 class="cta-h" data-split>Get Started with apogee</h2>
           <p class="cta-p reveal">Install it, open any page, and press Alt+Shift+U.</p>
           <a class="btn btn-fill cta-b1" href="https://addons.mozilla.org/en-US/firefox/addon/apogeeext/" target="_blank" rel="noopener">
-            ADD TO FIREFOX <span class="arw">&#8599;</span>
+            Add to Firefox <span class="arw" aria-hidden="true">&#8599;</span>
           </a>
           <a class="btn btn-out cta-b2" href="https://chromewebstore.google.com/detail/apogee/pgemlpomhkdcjjjcpnjlebalnfglomog" target="_blank" rel="noopener">
-            Add to Chrome <span class="arw">&#8599;</span>
+            Add to Chrome <span class="arw" aria-hidden="true">&#8599;</span>
           </a>
         </div>
       </section>
@@ -207,24 +208,24 @@
       <footer class="foot">
         <div class="wrap foot-grid">
           <div class="fcol">
-            <h4>Install</h4>
+            <h3>Install</h3>
             <a href="https://addons.mozilla.org/en-US/firefox/addon/apogeeext/" target="_blank" rel="noopener">Firefox Add-ons</a>
             <a href="https://chromewebstore.google.com/detail/apogee/pgemlpomhkdcjjjcpnjlebalnfglomog" target="_blank" rel="noopener">Chrome Web Store</a>
           </div>
           <div class="fcol">
-            <h4>Learn</h4>
+            <h3>Learn</h3>
             <a href="#why">Why apogee</a>
             <a href="#features">Features</a>
           </div>
           <div class="fcol">
-            <h4>Source</h4>
+            <h3>Source</h3>
             <a href="https://github.com/darshi1337/apogee" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/darshi1337/apogee/blob/main/PRIVACY.md" target="_blank" rel="noopener">Privacy notice</a>
             <a href="https://github.com/darshi1337/apogee/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
             <a href="https://github.com/darshi1337/apogee/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
           </div>
           <div class="fcol">
-            <h4>Social</h4>
+            <h3>Social</h3>
             <div class="fsocial">
               <a href="https://github.com/darshi1337/apogee" target="_blank" rel="noopener" aria-label="apogee on GitHub">
                 <span class="ico ico-github" aria-hidden="true"></span>
@@ -250,6 +251,15 @@
         <div class="wrap foot-mark" aria-hidden="true">apogee</div>
       </footer>
     </main>
+    <noscript
+      ><style>
+        .reveal,
+        [data-split] .w {
+          opacity: 1;
+          transform: none;
+        }
+      </style></noscript
+    >
     <script src="app.js" defer></script>
   </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -84,6 +84,27 @@ body {
 img, svg { display: block; max-width: 100%; }
 a { color: inherit; text-decoration: none; }
 
+/* Skip link: visually hidden until keyboard focus lands on it. */
+.skip {
+  position: absolute;
+  left: 1rem;
+  top: -4rem;
+  z-index: 100;
+  padding: 0.75rem 1.25rem;
+  background: var(--ink);
+  color: #fff;
+  font-size: 1rem;
+  transition: top 0.2s ease;
+}
+.skip:focus-visible { top: 1rem; }
+
+/* One visible keyboard indicator for every control, on light and dark
+   surfaces alike (purple holds 3:1 against both). */
+:focus-visible {
+  outline: 3px solid var(--purple);
+  outline-offset: 3px;
+}
+
 /* Monochrome icons drawn from assets/icons via mask, so they keep inheriting
    `color` (and its hover transitions) the way inline SVG did. */
 .ico {
@@ -395,7 +416,7 @@ h4 { font-size: 1.75rem; }
   color: var(--text);
   margin-bottom: 0.75rem;
 }
-.cta-b1 { grid-column: 3; grid-row: 2; }
+.cta-b1 { grid-column: 3; grid-row: 2; text-transform: uppercase; }
 .cta-b2 { grid-column: 4; grid-row: 3; }
 .cta .btn {
   width: 100%;
@@ -412,7 +433,7 @@ h4 { font-size: 1.75rem; }
 }
 .foot-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.875rem; }
 .fcol { display: flex; flex-direction: column; gap: 1rem; }
-.fcol h4 {
+.fcol h3 {
   font-family: var(--body);
   font-size: 1rem;
   font-weight: 500;
@@ -482,6 +503,8 @@ h4 { font-size: 1.75rem; }
   html { scroll-behavior: auto; }
   .reveal { opacity: 1; transform: none; transition: none; }
   [data-split] .w { opacity: 1; transform: none; animation: none; }
+  .tile, .tile:hover { transform: none; }
+  .btn, .nav-links a, .ghlink, .fcol a, .fsocial a, .skip { transition: none; }
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
Closes #240. Audit order: keyboard, semantics, contrast. No ARIA where semantic HTML does the job.

Fixed
- Keyboard: skip link to content, one visible :focus-visible indicator that holds 3:1 on light and dark surfaces, decorative arrows hidden from assistive tech (4x).
- Headings: footer h4 to h3, order is now h1, h2, h3 with no skips. Features region labelled since its cards had no section heading.
- Decorative images marked decorative: hero mark and all 7 card illustrations (each repeats adjacent card text). Source tiles keep their names since that is their content.
- Motion: prefers-reduced-motion now also kills hover transitions and transforms. Noscript fallback so reveal content never stays invisible when JS fails.
- CTA casing: sentence case in markup with CSS uppercase (was literal all-caps).

Checked and fine
- Contrast, every text pairing, verified with the contrast script: muted on white 5.26, purple on white 5.05, white on purple 5.05, silver on dark 9.95, ink on tint 14.94, ink on grey 14.50. All pass AA.
- No theme toggle exists on the page, so there is no theme-btn to fix.
- Trademark: Mozilla appears only as font-family names in CSS, no endorsement implication.
- External links keep target _blank with noopener; left as is.

Verified: HTML parses with no mismatches, CSS braces balanced, no duplicate ids, heading order and alt coverage checked by script. docs/ was already outside Prettier conformance at HEAD; new lines follow the file style.