### PR TITLE
fix: quick audit wins (viewport, icons dup, CSP, ollama leak, abort drain, privateHosts count)

### DIFF
--- a/apogee-extension/lib/engines/ollamaClient.js
+++ b/apogee-extension/lib/engines/ollamaClient.js
@@ -113,6 +113,17 @@ export async function* chatStream(
       );
     }
     throw createConnectionError(OllamaError, "Ollama", host, err);
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Safe fallback: best-effort reader cancellation
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      // Safe fallback: best-effort release of reader lock
+    }
   }
 }
 

--- a/apogee-extension/lib/storage/activityAudit.js
+++ b/apogee-extension/lib/storage/activityAudit.js
@@ -1,5 +1,5 @@
 import { getSettings } from "./settings.js";
-import { shouldPersist } from "./pageCache.js";
+import { parsePrivateHosts, shouldPersist } from "./pageCache.js";
 
 const AUDIT_LOG_KEY = "apogee_activity_audit_log";
 const MAX_AUDIT_ENTRIES = 20;
@@ -89,8 +89,8 @@ export async function getActivityAuditSummary() {
     storageRetention: {
       saveHistory: settings.saveHistory !== false,
       cachedPagesCount: storageCount,
-      autoWipePrivateHosts: (settings.privateHosts || []).length > 0,
-      privateHostCount: (settings.privateHosts || []).length,
+      autoWipePrivateHosts: parsePrivateHosts(settings.privateHosts).length > 0,
+      privateHostCount: parsePrivateHosts(settings.privateHosts).length,
     },
   };
 }

--- a/apogee-extension/manifest.json
+++ b/apogee-extension/manifest.json
@@ -46,11 +46,12 @@
       "suggested_key": {
         "default": "Alt+Shift+A",
         "mac": "Alt+Shift+A"
-      }
+      },
+      "description": "Open Apogee"
     }
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; default-src 'self'; connect-src 'self' http://127.0.0.1:* http://localhost:* https://huggingface.co https://*.huggingface.co https://*.hf.co https://sponsor.ajay.app https://api.bilibili.com https://*.hdslb.com https://public.api.bsky.app; img-src 'self' data:; font-src 'self'; style-src 'self'"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; default-src 'self'; base-uri 'self'; object-src 'none'; connect-src 'self' http://127.0.0.1:* http://localhost:* https://huggingface.co https://*.huggingface.co https://*.hf.co https://sponsor.ajay.app https://api.bilibili.com https://*.hdslb.com https://public.api.bsky.app; img-src 'self' data:; font-src 'self'; style-src 'self'"
   },
   "background": {
     "service_worker": "background/service-worker.js",

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -267,7 +267,7 @@ async function* drainWebLLMStream(eng, completion, signal, onFinalStats) {
       interrupted = true;
       eng.interruptGenerate();
     }
-    if (interrupted) continue;
+    if (interrupted) break;
     const text = chunk.choices?.[0]?.delta?.content || "";
     if (text) yield text;
     reportWebLLMFinalStats(chunk, onFinalStats);

--- a/apogee-extension/ui/app.html
+++ b/apogee-extension/ui/app.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>apogee</title>
     <link rel="stylesheet" href="app.css" />
   </head>
@@ -974,7 +975,7 @@
       <form id="pasteDialogForm" class="input-dialog">
         <h2 id="pasteDialogTitle">Paste text to summarize</h2>
         <label for="pasteDialogInput">Add text below</label>
-        <textarea id="pasteDialogInput" rows="7" autofocus></textarea>
+        <textarea id="pasteDialogInput" rows="7"></textarea>
         <div class="input-dialog-actions">
           <button
             id="pasteDialogCancel"
@@ -990,7 +991,6 @@
 
     <p id="a11yAnnouncer" class="sr-only" role="status" aria-live="polite"></p>
 
-    <script type="module" src="icons.js"></script>
     <script type="module" src="app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
8 small fixes, each ~<=10 lines. Tests 569 pass, lint+format clean.

- ui/app.html: viewport meta, remove autofocus, remove duplicate icons.js script
- manifest.json: _execute_action description, CSP base-uri/object-src
- ollamaClient.js: finally cancel+releaseLock (mirrors llamaCppClient)
- offscreen.js: abort drain break instead of continue
- activityAudit.js: privateHosts count via parsePrivateHosts

Remaining larger issues filed in ~/Downloads/apogee-audit-remaining.md