### PR TITLE
fix: orphan view-state keys, dedupe highlight matcher, harden generate-text

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -90,6 +90,7 @@ import {
   saveViewState,
   saveViewStateIfJobMatches,
   removeViewState,
+  cleanupOrphanedViewStates,
 } from "../lib/storage/viewState.js";
 import {
   COULD_NOT_READ_THIS_PAGE_ERROR_MSG,
@@ -1069,6 +1070,21 @@ if (typeof chrome !== "undefined" && chrome.commands?.onCommand?.addListener) {
 if (typeof chrome !== "undefined" && chrome.tabs?.onRemoved?.addListener) {
   chrome.tabs.onRemoved.addListener((tabId) => {
     removeViewState(tabId).catch(() => {});
+    // Opportunistically purge legacy URL-keyed view states that predate the
+    // numeric-tab-id guard; they are never removed by removeViewState alone.
+    cleanupOrphanedViewStates().catch(() => {});
+  });
+}
+
+// One-time purge of legacy URL-keyed view states on install/startup.
+if (typeof chrome !== "undefined" && chrome.runtime?.onStartup?.addListener) {
+  chrome.runtime.onStartup.addListener(() => {
+    cleanupOrphanedViewStates().catch(() => {});
+  });
+}
+if (typeof chrome !== "undefined" && chrome.runtime?.onInstalled?.addListener) {
+  chrome.runtime.onInstalled.addListener(() => {
+    cleanupOrphanedViewStates().catch(() => {});
   });
 }
 
@@ -2203,6 +2219,10 @@ export async function summarizeMultiTab(tabsToSummarize) {
       return generateInTargetLanguage(chat, prompt, qLanguage, { translateFn });
     });
   } else {
+    // WebLLM/Transformers run inside the offscreen document. Multi-tab uses
+    // the single-shot "generate-text" route there (handled in
+    // offscreen/offscreen.js) because there is one synthesized prompt rather
+    // than a per-tab stream.
     await ensureOffscreenDocument();
     const response = await chrome.runtime.sendMessage({
       target: "offscreen",
@@ -2228,11 +2248,22 @@ export async function summarizeMultiTab(tabsToSummarize) {
     tabs: extractedResults.map((t) => ({ title: t.title, url: t.url })),
   };
 
-  await saveViewState(url, {
-    status: "completed",
-    summary: summaryResult,
-    pageData,
-  });
+  // The popup restores per-tab state via loadViewState(tabId), so the
+  // multi-tab result must live under the owning tab's numeric id. Keying by
+  // URL string used to create unreachable `popupViewState:https://...` keys
+  // that leaked raw URLs into key names and were never cleaned on tab close.
+  const ownerTabId = tabsToSummarize.find((t) => Number.isInteger(t?.id))?.id;
+  if (ownerTabId != null) {
+    await saveViewState(ownerTabId, {
+      view: "summaryView",
+      subview: "summary",
+      url,
+      streamId: null,
+      summaryText: summaryResult,
+      summaryLanguage: settings.summaryLanguage,
+      translationEngine: settings.translationEngine,
+    });
+  }
 
   if (typeof chrome !== "undefined" && chrome.notifications) {
     chrome.notifications.create(`${notificationId}-ready`, {

--- a/apogee-extension/content/highlight.js
+++ b/apogee-extension/content/highlight.js
@@ -1,62 +1,7 @@
-// SHARED WITH lib/retrieval/passageMatch.js - keep in sync
-//
-// This file is injected as a plain content script and cannot import anything, so the block below is duplicated in lib/retrieval/passageMatch.js, which is what the tests import. This copy is the one that actually runs. A test in tests/retrieval/passageMatch.test.js fails if the two drift apart.
-function escapeRegExp(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-const MAX_MATCH_TEXT_CHARS = 1500;
-
-function buildFlexibleMatcher(text) {
-  const trimmed = text.trim();
-  if (!trimmed || trimmed.length > MAX_MATCH_TEXT_CHARS) return null;
-  const escaped = escapeRegExp(trimmed).replace(/\s+/g, "\\s+");
-  if (!escaped) return null;
-  try {
-    return new RegExp(escaped, "i");
-  } catch {
-    return null;
-  }
-}
-
-function tryMatch(haystack, text) {
-  const re = buildFlexibleMatcher(text);
-  if (!re) return null;
-  const match = re.exec(haystack);
-  if (!match) return null;
-  return { start: match.index, end: match.index + match[0].length };
-}
-
-function splitIntoSpans(text) {
-  return text
-    .split(/(?<=[.!?])\s+|\n+/)
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .sort((a, b) => b.length - a.length);
-}
-
-const PREFIX_WINDOW_CHARS = 180;
-
-function findMatchingRange(pageText, chunkText) {
-  const haystack = pageText || "";
-  const needle = (chunkText || "").trim();
-  if (!haystack || !needle) return null;
-
-  const full = tryMatch(haystack, needle);
-  if (full) return full;
-
-  for (const span of splitIntoSpans(needle)) {
-    const spanMatch = tryMatch(haystack, span);
-    if (spanMatch) return spanMatch;
-  }
-
-  const prefix = needle.slice(0, PREFIX_WINDOW_CHARS);
-  if (prefix.length < needle.length) {
-    return tryMatch(haystack, prefix);
-  }
-  return null;
-}
-// END SHARED
+// The passage matcher lives in lib/retrieval/passageMatch.js and is bundled
+// into this content script by Vite (see vite.config.js), so there is a single
+// source of truth instead of a duplicated block.
+import { findMatchingRange } from "../lib/retrieval/passageMatch.js";
 
 function buildTextIndex(root) {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {

--- a/apogee-extension/eslint.config.js
+++ b/apogee-extension/eslint.config.js
@@ -30,6 +30,7 @@ export default [
   },
   {
     files: ["content/**/*.js"],
+    ignores: ["content/highlight.js"],
     languageOptions: { sourceType: "script" },
     rules: {
       "no-unused-vars": [
@@ -37,6 +38,11 @@ export default [
         { argsIgnorePattern: "^_", varsIgnorePattern: "^extract" },
       ],
     },
+  },
+  // Bundled by Vite as an ES module entry (imports the passage matcher).
+  {
+    files: ["content/highlight.js"],
+    languageOptions: { sourceType: "module" },
   },
   {
     files: ["content/content.js"],

--- a/apogee-extension/lib/retrieval/passageMatch.js
+++ b/apogee-extension/lib/retrieval/passageMatch.js
@@ -1,6 +1,6 @@
-// SHARED WITH content/highlight.js - keep in sync
-//
-// The highlighter runs as an injected content script, which is loaded as a plain file and cannot import anything, so the block below is duplicated there verbatim. This copy exists so the logic is testable; the copy in highlight.js is the one that actually runs. A test in tests/retrieval/passageMatch.test.js fails if the two drift apart.
+// Canonical passage matcher. content/highlight.js imports this module and
+// Vite bundles it into the injected content script, so this is the single
+// source of truth for matching logic.
 function escapeRegExp(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -56,4 +56,3 @@ export function findMatchingRange(pageText, chunkText) {
   }
   return null;
 }
-// END SHARED

--- a/apogee-extension/lib/storage/viewState.js
+++ b/apogee-extension/lib/storage/viewState.js
@@ -5,6 +5,27 @@ function viewStateKey(tabId) {
   return `popupViewState:${tabId}`;
 }
 
+/**
+ * Tab ids come from chrome.tabs and are non-negative integers. Anything else
+ * (null, undefined, a URL string, floats) must never become a storage key:
+ * `saveViewState(url, ...)` once created `popupViewState:https://...` keys
+ * that leaked raw URLs into key names, were unreachable via
+ * `loadViewState(tabId)`, and were never removed by `removeViewState(tabId)`
+ * on tab close.
+ */
+export function isValidTabId(tabId) {
+  return typeof tabId === "number" && Number.isInteger(tabId) && tabId >= 0;
+}
+
+/** Whether a view-state key is a legacy orphan keyed by something other than a numeric tab id. */
+export function isOrphanedViewStateKey(key) {
+  return (
+    typeof key === "string" &&
+    key.startsWith("popupViewState:") &&
+    !/^\d+$/.test(key.slice("popupViewState:".length))
+  );
+}
+
 const MAX_VIEW_STATES = 50;
 
 const acquireViewStateLock = createLock();
@@ -24,7 +45,7 @@ async function preparePartial(partial) {
 }
 
 async function writeViewState(tabId, partial, expectedJob = null) {
-  if (tabId == null) return null;
+  if (!isValidTabId(tabId)) return null;
   const prepared = await preparePartial(partial);
   const release = await acquireViewStateLock();
   try {
@@ -78,7 +99,7 @@ export function saveViewStateIfJobMatches(
 }
 
 export async function loadViewState(tabId) {
-  if (tabId == null) return null;
+  if (!isValidTabId(tabId)) return null;
   const key = viewStateKey(tabId);
   const stored = await chrome.storage.local.get(key);
   return stored[key] || null;
@@ -106,7 +127,7 @@ export async function clearAllViewStates() {
 }
 
 export async function removeViewState(tabId) {
-  if (tabId == null) return;
+  if (!isValidTabId(tabId)) return;
   const release = await acquireViewStateLock();
   try {
     const key = viewStateKey(tabId);
@@ -115,6 +136,39 @@ export async function removeViewState(tabId) {
     const order = viewStateOrder.filter((k) => k !== key);
     await chrome.storage.local.set({ viewStateOrder: order });
     await chrome.storage.local.remove(key);
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Remove legacy view-state entries keyed by something other than a numeric
+ * tab id (e.g. `popupViewState:https://...` written by multi-tab
+ * summarization before it used the owning tab's id), and drop their entries
+ * from the order index. Runs under the same lock as the writers. Returns the
+ * number of storage keys removed.
+ */
+export async function cleanupOrphanedViewStates() {
+  const release = await acquireViewStateLock();
+  try {
+    const all = await chrome.storage.local.get(null);
+    const orphanKeys = Object.keys(all).filter(isOrphanedViewStateKey);
+    if (orphanKeys.length === 0) {
+      const order = all.viewStateOrder;
+      if (!Array.isArray(order)) return 0;
+      const pruned = order.filter((k) => !isOrphanedViewStateKey(k));
+      if (pruned.length !== order.length) {
+        await chrome.storage.local.set({ viewStateOrder: pruned });
+        return order.length - pruned.length;
+      }
+      return 0;
+    }
+    const order = Array.isArray(all.viewStateOrder)
+      ? all.viewStateOrder.filter((k) => !orphanKeys.includes(k))
+      : [];
+    await chrome.storage.local.set({ viewStateOrder: order });
+    await chrome.storage.local.remove(orphanKeys);
+    return orphanKeys.length;
   } finally {
     release();
   }

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -853,9 +853,23 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           break;
         }
 
+        // Single-shot (non-streaming) generation for multi-tab synthesis in
+        // service-worker.js summarizeMultiTab, which combines several tabs
+        // into one prompt and cannot use the streaming summarize/ask job
+        // flow. Registered route: service-worker sends
+        // { target: "offscreen", action: "generate-text" } for the
+        // WebLLM/Transformers providers.
         case "generate-text": {
+          const payload =
+            message.payload && typeof message.payload === "object"
+              ? message.payload
+              : {};
           const { prompt, model, provider, language, translationEngine } =
-            message.payload;
+            payload;
+          if (typeof prompt !== "string" || !prompt.trim()) {
+            sendResponse({ error: "generate-text requires a prompt" });
+            break;
+          }
           const qLanguage = await resolveEffectiveLanguage("", language);
           const translateFn = opusTranslateFor(translationEngine);
           const text =

--- a/apogee-extension/tests/retrieval/passageMatch.test.js
+++ b/apogee-extension/tests/retrieval/passageMatch.test.js
@@ -3,29 +3,32 @@ import assert from "node:assert";
 import { readFileSync } from "node:fs";
 import { findMatchingRange } from "../../lib/retrieval/passageMatch.js";
 
-// The matcher below is duplicated into content/highlight.js, which is injected as a plain script and cannot import it. Without this guard the tests would happily pass while the code that actually highlights passages drifts away from the code being tested.
-function sharedBlock(path) {
-  const src = readFileSync(new URL(path, import.meta.url), "utf8");
-  const start = src.indexOf("function escapeRegExp");
-  const end = src.indexOf("// END SHARED");
-  assert.ok(
-    start !== -1 && end > start,
-    `${path} is missing the shared matcher markers`,
+// content/highlight.js is bundled by Vite and imports the matcher below, so
+// there is one implementation. This guard fails if someone reintroduces a
+// duplicated matcher into the content script instead of importing it.
+test("content/highlight.js imports the canonical matcher instead of duplicating it", () => {
+  const highlightSrc = readFileSync(
+    new URL("../../content/highlight.js", import.meta.url),
+    "utf8",
   );
-  return src
-    .slice(start, end)
-    .replace(/^export /gm, "")
-    .trimEnd();
-}
-
-test("the matcher in content/highlight.js is identical to the one under test", () => {
-  assert.strictEqual(
-    sharedBlock("../../content/highlight.js"),
-    sharedBlock("../../lib/retrieval/passageMatch.js"),
-    "content/highlight.js and lib/retrieval/passageMatch.js have drifted apart. " +
-      "The content script is the copy that runs; edit both, or these tests stop " +
-      "saying anything about the shipped highlighter.",
+  assert.match(
+    highlightSrc,
+    /from\s+["']\.\.\/lib\/retrieval\/passageMatch\.js["']/,
+    "content/highlight.js must import findMatchingRange from lib/retrieval/passageMatch.js",
   );
+  for (const duplicated of [
+    "function escapeRegExp",
+    "function buildFlexibleMatcher",
+    "function tryMatch",
+    "function splitIntoSpans",
+    "PREFIX_WINDOW_CHARS",
+    "MAX_MATCH_TEXT_CHARS",
+  ]) {
+    assert.ok(
+      !highlightSrc.includes(duplicated),
+      `content/highlight.js must not duplicate the matcher (${duplicated} found); import it instead.`,
+    );
+  }
 });
 
 test("findMatchingRange finds an exact match", () => {

--- a/apogee-extension/tests/storage/viewState.test.js
+++ b/apogee-extension/tests/storage/viewState.test.js
@@ -8,6 +8,9 @@ import {
   clearAllViewStates,
   isViewStateKey,
   removeViewState,
+  cleanupOrphanedViewStates,
+  isValidTabId,
+  isOrphanedViewStateKey,
 } from "../../lib/storage/viewState.js";
 import { hashUrl } from "../../lib/storage/pageCache.js";
 
@@ -247,6 +250,72 @@ test("saveViewState returns null and writes nothing for null tabId", async () =>
     await saveViewState(undefined, { view: "homeView" }),
     null,
   );
+});
+
+test("saveViewState rejects non-numeric tab ids instead of creating orphan keys", async () => {
+  const data = installFakeStorage({ settings: { saveHistory: true } });
+  assert.strictEqual(
+    await saveViewState("https://example.com/article", {
+      view: "summaryView",
+    }),
+    null,
+  );
+  assert.strictEqual(await saveViewState("7", { view: "summaryView" }), null);
+  assert.strictEqual(await saveViewState(7.5, { view: "summaryView" }), null);
+  assert.strictEqual(await saveViewState(-1, { view: "summaryView" }), null);
+  assert.strictEqual(await saveViewState(NaN, { view: "summaryView" }), null);
+  assert.deepStrictEqual(
+    Object.keys(data).filter((k) => k.startsWith("popupViewState:")),
+    [],
+  );
+  assert.strictEqual(data.viewStateOrder, undefined);
+  assert.strictEqual(await loadViewState("https://example.com/a"), null);
+  assert.strictEqual(await loadViewState("7"), null);
+  // String ids must not throw or delete anything either.
+  await removeViewState("https://example.com/a");
+  assert.deepStrictEqual(
+    Object.keys(data).filter((k) => k.startsWith("popupViewState:")),
+    [],
+  );
+});
+
+test("isValidTabId only accepts non-negative integer tab ids", () => {
+  assert.strictEqual(isValidTabId(0), true);
+  assert.strictEqual(isValidTabId(7), true);
+  assert.strictEqual(isValidTabId("7"), false);
+  assert.strictEqual(isValidTabId("https://example.com"), false);
+  assert.strictEqual(isValidTabId(1.5), false);
+  assert.strictEqual(isValidTabId(-1), false);
+  assert.strictEqual(isValidTabId(null), false);
+  assert.strictEqual(isValidTabId(undefined), false);
+});
+
+test("cleanupOrphanedViewStates removes legacy URL-keyed states and prunes the order index", async () => {
+  const data = installFakeStorage({
+    settings: { saveHistory: true },
+    "popupViewState:https://example.com/article?token=hunter2": {
+      view: "summaryView",
+    },
+    "popupViewState:7": { view: "summaryView" },
+    viewStateOrder: [
+      "popupViewState:7",
+      "popupViewState:https://example.com/article?token=hunter2",
+    ],
+  });
+  assert.strictEqual(isOrphanedViewStateKey("popupViewState:7"), false);
+  assert.strictEqual(
+    isOrphanedViewStateKey("popupViewState:https://example.com/a"),
+    true,
+  );
+  const removed = await cleanupOrphanedViewStates();
+  assert.strictEqual(removed, 1);
+  assert.strictEqual(
+    data["popupViewState:https://example.com/article?token=hunter2"],
+    undefined,
+  );
+  assert.notStrictEqual(data["popupViewState:7"], undefined);
+  assert.deepStrictEqual(data.viewStateOrder, ["popupViewState:7"]);
+  assert.ok(!JSON.stringify(data).includes("hunter2"));
 });
 
 test("saveViewStateIfJobMatches returns null for falsy jobId", async () => {

--- a/apogee-extension/vite.config.js
+++ b/apogee-extension/vite.config.js
@@ -45,8 +45,13 @@ function copyStaticPlugin(targetBrowser) {
         recursive: true,
       });
 
+      // content/highlight.js is a bundled Vite entry (it imports the
+      // passage matcher from lib/), so skip the raw source file here and
+      // keep the bundled output that already landed at dist/content/.
       cpSync(resolve(__dirname, "content"), resolve(dist, "content"), {
         recursive: true,
+        filter: (src) =>
+          !src.replace(/\\/g, "/").endsWith("content/highlight.js"),
       });
 
       cpSync(resolve(__dirname, "rules"), resolve(dist, "rules"), {
@@ -91,6 +96,10 @@ export default defineConfig(() => {
       __dirname,
       "background/service-worker.js",
     ),
+    // Bundled so content/highlight.js can import the passage matcher from
+    // lib/ instead of duplicating it; output lands at content/highlight.js,
+    // the same path ui/app.js injects via chrome.scripting.executeScript.
+    "content/highlight": resolve(__dirname, "content/highlight.js"),
     "pdf.worker": resolve(
       __dirname,
       "node_modules/pdfjs-dist/build/pdf.worker.mjs",


### PR DESCRIPTION
Fixes the three unused & redundant code findings:

**1. Orphaned view-state keys (real bug)**
- `summarizeMultiTab` called `saveViewState(url, ...)` with a URL string, creating `popupViewState:https://...` keys that leaked raw URLs (incl. query tokens) into key names, were unreachable via `loadViewState(tabId)`, and bypassed `removeViewState(tabId)` on tab close.
- Now saves the multi-tab result under the owning tab's numeric id with the standard popup shape (`view/subview/summaryText`), skipping the write when no numeric tab id exists.
- `lib/storage/viewState.js` now rejects non-integer tab ids in `save/load/remove` via `isValidTabId`, and adds `cleanupOrphanedViewStates()` (plus `isOrphanedViewStateKey`) to purge legacy URL-keyed entries and prune `viewStateOrder`.
- Cleanup runs opportunistically on tab close and on install/startup.

**2. highlight.js / passageMatch.js duplication**
- `content/highlight.js` now imports `findMatchingRange` from `lib/retrieval/passageMatch.js`; added as a Vite bundle entry so the shipped `dist/content/highlight.js` is self-contained (verified: 0 imports, matcher inlined).
- `copyStaticPlugin` skips the raw source file so it never overwrites the bundle; `eslint.config.js` treats highlight.js as a module.
- Drift test now asserts single-source-of-truth (imports canonical module, contains no duplicated matcher) instead of asserting two copies are identical.

**3. generate-text offscreen route**
- Kept: it is the registered single-shot route for multi-tab synthesis (WebLLM/Transformers), exercised by context-menu + `summarize-multi-tab` message and covered by `multiTabSummarize.test.js` — deleting it would break that path.
- Hardened with payload validation (`generate-text requires a prompt`) and documented both ends (offscreen handler + service-worker caller).

Verification: 572/572 tests pass, eslint clean, chrome+firefox builds succeed with bundled `content/highlight.js`.