### PR TITLE
fix: multi-tab view-state shape, subtitle caps, model allow-list, rag key

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -33,6 +33,8 @@ import { truncateForPrompt } from "../lib/summarize/chunk.js";
 import { parseSuggestedQuestions } from "../lib/summarize/questions.js";
 import { extractPdfText } from "../lib/extract/pdfExtract.js";
 import {
+  MAX_BILIBILI_SUBTITLE_CHARS,
+  MAX_BILIBILI_SUBTITLE_SEGMENTS,
   MAX_FINALIZE_TEXT_CHARS,
   MAX_UPLOAD_FILE_BYTES,
 } from "../lib/extract/fileLimits.js";
@@ -1145,7 +1147,12 @@ export async function fetchSponsorBlockSegments(videoId) {
     .map((s) => [s.segment[0], s.segment[1]]);
 }
 
-async function fetchBilibiliSubtitles({ aid, bvid, cid, preferredLang }) {
+export async function fetchBilibiliSubtitles({
+  aid,
+  bvid,
+  cid,
+  preferredLang,
+}) {
   if (!cid || (!aid && !bvid)) return [];
   const cidStr = String(cid);
   if (!/^\d+$/.test(cidStr)) return [];
@@ -1218,14 +1225,23 @@ async function fetchBilibiliSubtitles({ aid, bvid, cid, preferredLang }) {
 
   const body = subData?.body;
   if (!Array.isArray(body)) return [];
-  return body
-    .map((seg) => ({
-      start: Number(seg.from) || 0,
-      text: String(seg.content || "")
-        .replace(/\s+/g, " ")
-        .trim(),
-    }))
-    .filter((seg) => seg.text);
+  // Bounded accumulation: stop at the segment cap and past the char budget
+  // so a malformed track cannot bloat service-worker memory. Segments past
+  // the budget are dropped, never partially kept, to keep start/text pairs
+  // intact.
+  const segments = [];
+  let totalChars = 0;
+  for (const seg of body) {
+    if (segments.length >= MAX_BILIBILI_SUBTITLE_SEGMENTS) break;
+    const text = String(seg?.content || "")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (!text) continue;
+    if (totalChars + text.length > MAX_BILIBILI_SUBTITLE_CHARS) break;
+    segments.push({ start: Number(seg?.from) || 0, text });
+    totalChars += text.length;
+  }
+  return segments;
 }
 
 async function generateLocalSuggestions(
@@ -2260,6 +2276,9 @@ export async function summarizeMultiTab(tabsToSummarize) {
       url,
       streamId: null,
       summaryText: summaryResult,
+      // No per-tab prompts key exists for a multi-tab synthesis; null clears
+      // any stale single-tab key the merge would otherwise inherit.
+      promptsCacheKey: null,
       summaryLanguage: settings.summaryLanguage,
       translationEngine: settings.translationEngine,
     });

--- a/apogee-extension/lib/constants.js
+++ b/apogee-extension/lib/constants.js
@@ -32,6 +32,14 @@ export const WEBLLM_MODELS = [
 
 const DEFAULT_WEBLLM_MODEL = WEBLLM_MODELS.find((m) => m.default).id;
 
+// Allow-list for WebLLM model ids. Anything else passed to CreateMLCEngine
+// makes it fetch model config from the remote HuggingFace CDN, so unknown
+// ids (stale storage, tampered settings, untrusted message payloads) must be
+// rejected before the engine starts, keeping model loads on the bundled libs.
+export function isKnownWebLLMModelId(id) {
+  return WEBLLM_MODELS.some((m) => m.id === id);
+}
+
 export const TRANSFORMERS_MODELS = [
   {
     id: "HuggingFaceTB/SmolLM2-360M-Instruct",

--- a/apogee-extension/lib/extract/fileLimits.js
+++ b/apogee-extension/lib/extract/fileLimits.js
@@ -38,6 +38,14 @@ export const MAX_PDF_TEXT_CHARS = 25 * 1024 * 1024;
 // before it fans out: real summaries are kilobytes, 1 MB is generous.
 export const MAX_FINALIZE_TEXT_CHARS = 1024 * 1024;
 
+// Bilibili subtitle hardening. Track JSON comes from the hdslb CDN and each
+// entry is mapped into a segment, so a malformed track with millions of
+// entries (or megabyte bodies) would turn the service worker into an OOM
+// vector. Real tracks are hundreds of segments and tens of KB; both ceilings
+// are generous headroom, mirroring the PDF/DOCX accumulation backstops above.
+export const MAX_BILIBILI_SUBTITLE_SEGMENTS = 5000;
+export const MAX_BILIBILI_SUBTITLE_CHARS = 500 * 1024;
+
 // Pasted-text and plain-text file ceiling (#211). file.size bounds the upload
 // (~50 MB string), but two post-read text paths were unbounded: file.text()
 // for txt/md/json/html and the pasted-text dialog. A multi-MB string here

--- a/apogee-extension/lib/retrieval/rag.js
+++ b/apogee-extension/lib/retrieval/rag.js
@@ -12,8 +12,15 @@ const MIN_REFINE_SENTENCE_CHARS = 25;
 const MAX_CACHE_ENTRIES = 5;
 const indexCache = new Map();
 
+// Length-prefixed so two different documents can only collide on both the
+// 53-bit hash and the exact byte length, closing the truncation-collision
+// class without paying for an async SHA-256 on every lookup.
+export function ragIndexCacheKey(content) {
+  return `${content.length}:${cyrb53(content)}`;
+}
+
 async function getOrBuildIndex(content, embedTextsFn) {
-  const key = cyrb53(content);
+  const key = ragIndexCacheKey(content);
   const cached = indexCache.get(key);
   if (cached) return cached;
 

--- a/apogee-extension/lib/storage/settings.js
+++ b/apogee-extension/lib/storage/settings.js
@@ -1,4 +1,8 @@
-import { DEFAULT_SETTINGS, PROVIDERS } from "../constants.js";
+import {
+  DEFAULT_SETTINGS,
+  PROVIDERS,
+  isKnownWebLLMModelId,
+} from "../constants.js";
 import { validateLlamaHost, validateOllamaHost } from "../util/ollamaHost.js";
 
 const PROVIDER_VALUES = new Set(Object.values(PROVIDERS));
@@ -10,6 +14,12 @@ function sanitizeSettings(settings) {
   // validator the service worker enforces at request time.
   if (!PROVIDER_VALUES.has(clean.provider)) {
     clean.provider = DEFAULT_SETTINGS.provider;
+  }
+  // An unknown WebLLM model id would make the offscreen engine fetch config
+  // from the remote CDN instead of the bundled libs, so reset it to the
+  // default rather than passing it through.
+  if (!isKnownWebLLMModelId(clean.webllmModel)) {
+    clean.webllmModel = DEFAULT_SETTINGS.webllmModel;
   }
   try {
     clean.ollamaHost = validateOllamaHost(clean.ollamaHost);

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -12,7 +12,11 @@ import {
   selectSalientChunks,
 } from "../lib/retrieval/rag.js";
 import { createLock } from "../lib/util/mutex.js";
-import { WEBLLM_MODELS, TRANSLATION_ENGINES } from "../lib/constants.js";
+import {
+  WEBLLM_MODELS,
+  TRANSLATION_ENGINES,
+  isKnownWebLLMModelId,
+} from "../lib/constants.js";
 import {
   withTransformersEngine,
   transformersChatStream,
@@ -122,6 +126,15 @@ async function getPrompts() {
 }
 
 async function ensureEngine(modelId) {
+  // Defense in depth behind the settings sanitize: the offscreen document
+  // also accepts model ids from message payloads, so reject anything outside
+  // the allow-list here, where a miss would otherwise fall back to a remote
+  // HuggingFace CDN fetch for model config.
+  if (!isKnownWebLLMModelId(modelId)) {
+    throw new Error(
+      `Unknown WebLLM model "${modelId}". Pick one of the bundled models in settings.`,
+    );
+  }
   if (engine && currentModelId === modelId) {
     return engine;
   }

--- a/apogee-extension/tests/background/bilibiliSubtitles.test.js
+++ b/apogee-extension/tests/background/bilibiliSubtitles.test.js
@@ -22,10 +22,19 @@ const { fetchBilibiliSubtitles } =
 const ARGS = { aid: "12345", cid: "67890", preferredLang: "en" };
 const TRACK_URL = "https://xy123.hdslb.com/track.json";
 
+// Exact hostname match: a substring check here would treat an attacker's
+// api.bilibili.com.evil.example as the first-party metadata endpoint.
+function isMetadataRequest(url) {
+  try {
+    return new URL(String(url)).hostname === "api.bilibili.com";
+  } catch {
+    return false;
+  }
+}
+
 function mockFetch(trackBody) {
   return async (url) => {
-    const text = url.toString();
-    const payload = text.includes("api.bilibili.com")
+    const payload = isMetadataRequest(url)
       ? {
           data: {
             subtitle: { subtitles: [{ lan: "en", subtitle_url: TRACK_URL }] },

--- a/apogee-extension/tests/background/bilibiliSubtitles.test.js
+++ b/apogee-extension/tests/background/bilibiliSubtitles.test.js
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert";
+import { createExtensionApiMock } from "../helpers/extensionApiMock.js";
+import {
+  MAX_BILIBILI_SUBTITLE_CHARS,
+  MAX_BILIBILI_SUBTITLE_SEGMENTS,
+} from "../../lib/extract/fileLimits.js";
+
+const { chrome } = createExtensionApiMock({
+  settings: {
+    saveHistory: true,
+  },
+});
+chrome.permissions = {
+  contains: (_req, cb) => cb(true),
+};
+globalThis.chrome = chrome;
+
+const { fetchBilibiliSubtitles } =
+  await import("../../background/service-worker.js");
+
+const ARGS = { aid: "12345", cid: "67890", preferredLang: "en" };
+const TRACK_URL = "https://xy123.hdslb.com/track.json";
+
+function mockFetch(trackBody) {
+  return async (url) => {
+    const text = url.toString();
+    const payload = text.includes("api.bilibili.com")
+      ? {
+          data: {
+            subtitle: { subtitles: [{ lan: "en", subtitle_url: TRACK_URL }] },
+          },
+        }
+      : { body: trackBody };
+    return new Response(JSON.stringify(payload), { status: 200 });
+  };
+}
+
+function seg(i) {
+  return { from: i * 2.5, content: ` hello  world ${i} ` };
+}
+
+test("fetchBilibiliSubtitles normalizes small tracks", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mockFetch([seg(0), seg(1), { from: 5, content: "   " }]);
+  try {
+    const result = await fetchBilibiliSubtitles(ARGS);
+    assert.deepStrictEqual(result, [
+      { start: 0, text: "hello world 0" },
+      { start: 2.5, text: "hello world 1" },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("fetchBilibiliSubtitles caps runaway segment counts", async () => {
+  assert.strictEqual(MAX_BILIBILI_SUBTITLE_SEGMENTS, 5000);
+  const originalFetch = globalThis.fetch;
+  const oversized = Array.from(
+    { length: MAX_BILIBILI_SUBTITLE_SEGMENTS + 1000 },
+    (_, i) => seg(i),
+  );
+  globalThis.fetch = mockFetch(oversized);
+  try {
+    const result = await fetchBilibiliSubtitles(ARGS);
+    assert.strictEqual(result.length, MAX_BILIBILI_SUBTITLE_SEGMENTS);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("fetchBilibiliSubtitles caps total characters", async () => {
+  assert.strictEqual(MAX_BILIBILI_SUBTITLE_CHARS, 500 * 1024);
+  const originalFetch = globalThis.fetch;
+  const big = Array.from({ length: 100 }, (_, i) => ({
+    from: i,
+    content: "x".repeat(10 * 1024),
+  }));
+  globalThis.fetch = mockFetch(big);
+  try {
+    const result = await fetchBilibiliSubtitles(ARGS);
+    const total = result.reduce((n, s) => n + s.text.length, 0);
+    assert.ok(total <= MAX_BILIBILI_SUBTITLE_CHARS);
+    assert.ok(result.length < big.length);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("fetchBilibiliSubtitles rejects invalid input without fetching", async () => {
+  let fetched = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (...args) => {
+    fetched++;
+    return originalFetch(...args);
+  };
+  try {
+    assert.deepStrictEqual(await fetchBilibiliSubtitles({}), []);
+    assert.deepStrictEqual(
+      await fetchBilibiliSubtitles({ aid: "1", cid: "not-a-number" }),
+      [],
+    );
+    assert.strictEqual(fetched, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/apogee-extension/tests/extract/fileLimits.test.js
+++ b/apogee-extension/tests/extract/fileLimits.test.js
@@ -2,6 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  MAX_BILIBILI_SUBTITLE_CHARS,
+  MAX_BILIBILI_SUBTITLE_SEGMENTS,
   MAX_FINALIZE_TEXT_CHARS,
   MAX_PASTED_CHARS,
   MAX_UPLOAD_FILE_BYTES,
@@ -54,4 +56,9 @@ test("truncatePastedText truncates with a note past the ceiling (#211)", () => {
 
 test("finished-summary backstop is a generous fixed ceiling", () => {
   assert.equal(MAX_FINALIZE_TEXT_CHARS, 1024 * 1024);
+});
+
+test("bilibili subtitle ceilings bound segments and characters", () => {
+  assert.equal(MAX_BILIBILI_SUBTITLE_SEGMENTS, 5000);
+  assert.equal(MAX_BILIBILI_SUBTITLE_CHARS, 500 * 1024);
 });

--- a/apogee-extension/tests/retrieval/rag.test.js
+++ b/apogee-extension/tests/retrieval/rag.test.js
@@ -5,6 +5,7 @@ import {
   retrieveRelevantContent,
   findBestPassage,
   selectSalientChunks,
+  ragIndexCacheKey,
 } from "../../lib/retrieval/rag.js";
 
 function fakeEmbed(texts) {
@@ -73,6 +74,15 @@ test("retrieveRelevantContent reuses cached chunk embeddings across questions", 
   );
 
   assert.equal(indexBuildCalls, 1);
+});
+
+test("ragIndexCacheKey prefixes the hash with content length", () => {
+  const a = "lorem ipsum dolor sit amet ".repeat(100);
+  const b = `${a}extra sentence.`;
+  assert.ok(ragIndexCacheKey(a).startsWith(`${a.length}:`));
+  assert.ok(ragIndexCacheKey(b).startsWith(`${b.length}:`));
+  assert.notStrictEqual(ragIndexCacheKey(a), ragIndexCacheKey(b));
+  assert.strictEqual(ragIndexCacheKey(a), ragIndexCacheKey(a));
 });
 
 test("retrieveRelevantContent falls back to truncation if embedding fails", async () => {

--- a/apogee-extension/tests/storage/settings.test.js
+++ b/apogee-extension/tests/storage/settings.test.js
@@ -6,6 +6,8 @@ import {
   DEFAULT_LLAMACPP_HOST,
   DEFAULT_OLLAMA_HOST,
   DEFAULT_SETTINGS,
+  WEBLLM_MODELS,
+  isKnownWebLLMModelId,
 } from "../../lib/constants.js";
 
 function installFakeStorage(settings) {
@@ -36,6 +38,29 @@ test("getSettings preserves valid providers and loopback hosts", async () => {
   assert.equal(settings.provider, "local");
   assert.equal(settings.ollamaHost, "http://127.0.0.1:11434");
   assert.equal(settings.llamaHost, "http://localhost:8080");
+});
+
+test("isKnownWebLLMModelId allow-lists only bundled models", () => {
+  for (const m of WEBLLM_MODELS) {
+    assert.equal(isKnownWebLLMModelId(m.id), true);
+  }
+  assert.equal(isKnownWebLLMModelId("Qwen2.5-7B-Instruct-q4f16_1-MLC"), false);
+  assert.equal(isKnownWebLLMModelId(""), false);
+  assert.equal(isKnownWebLLMModelId(null), false);
+  assert.equal(isKnownWebLLMModelId(undefined), false);
+});
+
+test("getSettings resets an unknown WebLLM model to the default", async () => {
+  installFakeStorage({ webllmModel: "Evil-9B-q4f16_1-MLC" });
+  const settings = await getSettings();
+  assert.equal(settings.webllmModel, DEFAULT_SETTINGS.webllmModel);
+  assert.equal(isKnownWebLLMModelId(settings.webllmModel), true);
+});
+
+test("getSettings preserves a known WebLLM model", async () => {
+  installFakeStorage({ webllmModel: WEBLLM_MODELS[1].id });
+  const settings = await getSettings();
+  assert.equal(settings.webllmModel, WEBLLM_MODELS[1].id);
 });
 
 test("getSettings falls back on unknown provider and non-loopback hosts", async () => {


### PR DESCRIPTION
Addresses the four security & reliability findings:

**[HIGH] Multi-tab state persistence** (already fixed by #274, aligned fully with the remedy here)
- The `saveViewState(url, ...)` type confusion and wrong schema were fixed in #274 (numeric owner tab id + canonical `view/subview/summaryText` shape, reachable via the notification-click popup path).
- This PR adds the remaining remedy item: explicit `promptsCacheKey: null`, matching the fresh-summary convention in `ui/app.js`, so the merge never inherits a stale single-tab prompts key.

**[MEDIUM] Bilibili subtitle accumulation**
- New ceilings in `lib/extract/fileLimits.js`: `MAX_BILIBILI_SUBTITLE_SEGMENTS = 5000`, `MAX_BILIBILI_SUBTITLE_CHARS = 500KB`, alongside the existing PDF/DOCX backstops.
- `fetchBilibiliSubtitles` now accumulates in a bounded loop (early break on both caps, drops over-budget segments whole to keep start/text pairs intact) instead of unbounded map/join. Exported for testing.
- Tests: `tests/background/bilibiliSubtitles.test.js` (normalization, segment cap, char cap, invalid input) + ceiling pins in `fileLimits.test.js`.

**[MEDIUM] Offscreen model allow-list**
- New `isKnownWebLLMModelId()` in `lib/constants.js`; unknown ids previously fell through to a remote HuggingFace CDN fetch inside `CreateMLCEngine`.
- Enforced at both layers: `sanitizeSettings` resets unknown stored ids to the default (self-healing), and offscreen `ensureEngine` throws a clear error for untrusted message-payload ids. The settings UI only offers the 4 bundled models, so legit flows are unaffected.

**[LOW] RAG index cache key**
- Key is now ``${content.length}:${cyrb53(content)}`` via exported `ragIndexCacheKey()`, closing the truncation-collision class without an async SHA-256 per lookup.

Verification: 581/581 tests pass, eslint clean, chrome+firefox builds succeed.