### PR TITLE
fix: bump addons-linter, guard dist from vulnerable dev-only packages

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,6 +37,18 @@ jobs:
 
       - run: npm run build
 
+      - name: Verify vulnerable dev-only packages never ship in dist
+        run: |
+          # adm-zip (via onnxruntime-node/firefox-profile) and image-size (via
+          # addons-linter) carry unpatched advisories but must stay dev-only:
+          # Vite only bundles imported modules, so none of these may appear in
+          # the shipped bundles. onnxruntime-web WASM ("ort-wasm") is expected.
+          LEAKED=$(grep -rl --exclude='*.map' -e 'adm-zip' -e 'AdmZip' -e 'image-size' -e 'onnxruntime-node' -e 'firefox-profile' -e 'FirefoxProfile' dist/chrome dist/firefox || true)
+          if [ -n "$LEAKED" ]; then
+            echo "::error::dev-only vulnerable package leaked into dist:"; echo "$LEAKED"; exit 1;
+          fi
+          echo "dist is free of adm-zip/image-size/onnxruntime-node/firefox-profile"
+
       - name: Verify Firefox manifest transform
         run: |
           node -e '

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,10 +2,17 @@ name: Security scans
 
 # Complements CodeQL + dependency-review:
 # - Gitleaks is BLOCKING (fake test keys are allowlisted in .gitleaks.toml).
-# - OSV + npm audit are REPORT-ONLY: addons-linter pulls a known-vulnerable
-#   image-size whose fix needs a breaking major bump, so failing the build
-#   here would keep main red until that migration lands. Triage the uploaded
-#   reports instead.
+# - OSV + npm audit are REPORT-ONLY: the only findings trace to two advisories
+#   with no patched version published upstream —
+#     * adm-zip symlink traversal (latest 0.6.0 still flagged; pinned via
+#       overrides; audit's only "fix" is downgrading transformers, rejected)
+#     * image-size parser DoS (latest 2.0.2 still flagged; latest
+#       addons-linter 10.11.0 still ships it)
+#   Both are dev-only/install-time and never ship in dist/ (enforced by the
+#   "vulnerable dev-only packages" guard in package.yml), so failing the build
+#   here would keep main red with no actionable upgrade. Triage the uploaded
+#   reports instead, and re-test an addons-linter bump whenever upstream
+#   publishes fixed image-parser dependencies.
 
 on:
   push:
@@ -70,7 +77,7 @@ jobs:
           npm audit --audit-level=high --json > /tmp/npm-audit.json || true
           HIGH=$(node -e 'const r=require("/tmp/npm-audit.json"); const v=(r.metadata&&r.metadata.vulnerabilities)||{}; console.log((v.high||0)+" high, "+(v.critical||0)+" critical")')
           echo "### npm audit (report-only): $HIGH" >> "$GITHUB_STEP_SUMMARY"
-          echo "Known issue: image-size via addons-linter/web-ext needs a breaking major bump; triage before promoting to blocking." >> "$GITHUB_STEP_SUMMARY"
+          echo "Known issues, both unpatched upstream and dev-only (never in dist/): adm-zip via onnxruntime-node/firefox-profile, image-size via addons-linter/web-ext. Triage before promoting to blocking." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload audit reports
         uses: actions/upload-artifact@v7

--- a/apogee-extension/package-lock.json
+++ b/apogee-extension/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "addons-linter": "^10.10.0",
+        "addons-linter": "^10.11.0",
         "eslint": "^10.10.0",
         "eslint-config-prettier": "^10.1.8",
         "globals": "^17.12.0",
@@ -1058,9 +1058,9 @@
       "license": "MIT"
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-8.0.8.tgz",
-      "integrity": "sha512-Rutrrc3FYOc+um4/QC4WFETNk2fV8NKWoqQl3tQfcVTQ1WFaoJRbsJBasSF34ltitmnYYD6ZsKW1cOQtSj1jbQ==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-8.0.13.tgz",
+      "integrity": "sha512-jR1x+1UHDwYUBr2JLOuLucZGyAF7XphpxFbWQoUSwKgHt2zlMidfRSJ/0C3yC7vRBxMOjJF2edptu8kz0BGWrw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1783,17 +1783,17 @@
       }
     },
     "node_modules/addons-linter": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-10.10.0.tgz",
-      "integrity": "sha512-1n5Xvn4DyHMsulchNDl4ucWnXXQhHwLif6eK80KjieI9KIK3xD+3OYXk5ZcA6a2J8y+Nrlvq9/vq6w7KOqT2MQ==",
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-10.11.0.tgz",
+      "integrity": "sha512-kLE8zXbzPU9Umq08pNQxouKzMXvBGVC6KJWudi/dqeBqRuQsWKrSS4KpaRKU2qHTlrUapx0DmeH0vUoZ+uoJaA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@fluent/syntax": "0.19.0",
         "@fregante/relaxed-json": "2.0.0",
-        "@mdn/browser-compat-data": "8.0.8",
+        "@mdn/browser-compat-data": "8.0.13",
         "addons-moz-compare": "1.3.0",
-        "addons-scanner-utils": "15.4.0",
+        "addons-scanner-utils": "15.5.0",
         "ajv": "8.20.0",
         "cheerio": "1.2.0",
         "columnify": "1.6.0",
@@ -1983,9 +1983,9 @@
       "license": "MPL-2.0"
     },
     "node_modules/addons-scanner-utils": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-15.4.0.tgz",
-      "integrity": "sha512-i3PnJx9YLZi96o4t4JWArP6JimC01949YVAcMJKHfyQ5qmUBaH21qNS8f12/RsloejW8IcCEljhh3Fq3gxFNsg==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-15.5.0.tgz",
+      "integrity": "sha512-bucvaWBYzhtIVrkbzSo9SA22DLsOxFKXLlIJ234N6x8+8a3FNDGOva8x9lsM7xVQ7oUZH4RZ/WAEtR54J/iQSg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -1993,7 +1993,7 @@
         "first-chunk-stream": "3.0.0",
         "jsonwebtoken": "^9.0.3",
         "strip-bom-stream": "4.0.0",
-        "upath": "3.0.7",
+        "upath": "3.0.8",
         "yauzl": "3.4.0"
       },
       "peerDependencies": {
@@ -2007,30 +2007,6 @@
         "safe-compare": {
           "optional": true
         }
-      }
-    },
-    "node_modules/addons-scanner-utils/node_modules/upath": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-3.0.7.tgz",
-      "integrity": "sha512-VjBBquch25nUGMuVBpOb2Cj3gc8Kb7lJBqbsXR/0anZ/5uJsL14Kpth9JKfnBsckxCfgIp6hPvcvvmZ97R9X7g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/anodynos"
-        },
-        {
-          "type": "polar",
-          "url": "https://polar.sh/anodynos"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-upath"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/adm-zip": {
@@ -6469,6 +6445,257 @@
         "node": ">=20.0.0",
         "npm": ">=8.0.0"
       }
+    },
+    "node_modules/web-ext/node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/web-ext/node_modules/@mdn/browser-compat-data": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-8.0.8.tgz",
+      "integrity": "sha512-Rutrrc3FYOc+um4/QC4WFETNk2fV8NKWoqQl3tQfcVTQ1WFaoJRbsJBasSF34ltitmnYYD6ZsKW1cOQtSj1jbQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/web-ext/node_modules/addons-linter": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-10.10.0.tgz",
+      "integrity": "sha512-1n5Xvn4DyHMsulchNDl4ucWnXXQhHwLif6eK80KjieI9KIK3xD+3OYXk5ZcA6a2J8y+Nrlvq9/vq6w7KOqT2MQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@fluent/syntax": "0.19.0",
+        "@fregante/relaxed-json": "2.0.0",
+        "@mdn/browser-compat-data": "8.0.8",
+        "addons-moz-compare": "1.3.0",
+        "addons-scanner-utils": "15.4.0",
+        "ajv": "8.20.0",
+        "cheerio": "1.2.0",
+        "columnify": "1.6.0",
+        "common-tags": "1.8.2",
+        "css-tree": "3.2.1",
+        "deepmerge": "4.3.1",
+        "eslint": "9.39.4",
+        "eslint-plugin-no-unsanitized": "4.1.5",
+        "eslint-visitor-keys": "5.0.1",
+        "espree": "11.2.0",
+        "esprima": "4.0.1",
+        "fast-json-patch": "3.1.1",
+        "image-size": "2.0.2",
+        "json-merge-patch": "1.0.2",
+        "pino": "10.3.1",
+        "semver": "7.8.5",
+        "source-map-support": "0.5.21",
+        "upath": "3.0.8",
+        "yargs": "17.7.2",
+        "yauzl": "3.4.0"
+      },
+      "bin": {
+        "addons-linter": "bin/addons-linter"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/web-ext/node_modules/addons-scanner-utils": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-15.4.0.tgz",
+      "integrity": "sha512-i3PnJx9YLZi96o4t4JWArP6JimC01949YVAcMJKHfyQ5qmUBaH21qNS8f12/RsloejW8IcCEljhh3Fq3gxFNsg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "common-tags": "1.8.2",
+        "first-chunk-stream": "3.0.0",
+        "jsonwebtoken": "^9.0.3",
+        "strip-bom-stream": "4.0.0",
+        "upath": "3.0.7",
+        "yauzl": "3.4.0"
+      },
+      "peerDependencies": {
+        "express": "5.2.1",
+        "safe-compare": "1.1.4"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        },
+        "safe-compare": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-ext/node_modules/addons-scanner-utils/node_modules/upath": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-3.0.7.tgz",
+      "integrity": "sha512-VjBBquch25nUGMuVBpOb2Cj3gc8Kb7lJBqbsXR/0anZ/5uJsL14Kpth9JKfnBsckxCfgIp6hPvcvvmZ97R9X7g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/anodynos"
+        },
+        {
+          "type": "polar",
+          "url": "https://polar.sh/anodynos"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-upath"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/web-ext/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/web-ext/node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-ext/node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/web-ext/node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/web-ext/node_modules/eslint/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/web-ext/node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-ext/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/web-ext/node_modules/strip-json-comments": {
       "version": "5.0.3",

--- a/apogee-extension/package.json
+++ b/apogee-extension/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "addons-linter": "^10.10.0",
+    "addons-linter": "^10.11.0",
     "eslint": "^10.10.0",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.12.0",


### PR DESCRIPTION
Addresses the dependencies & supply chain audit findings.

**Key result: neither root advisory is patchable by upgrade.**
- `adm-zip` symlink traversal: overrides already pin the newest published version (0.6.0), but the advisory range covers all versions. Audit's only suggested fix is downgrading `@huggingface/transformers` to 3.8.1 (breaking, wrong direction) — rejected.
- `image-size` parser DoS: newest published is 2.0.2 (installed), advisory range is `*`. Latest `addons-linter` 10.11.0 still ships it, so re-testing the upgrade yields no fix yet.

**Changes:**
1. `apogee-extension/package.json` + lockfile — bumped `addons-linter` ^10.10.0 → ^10.11.0 (latest; `lint:webext` passes with 0 errors). Overrides for adm-zip/sharp/js-yaml/brace-expansion kept and verified effective via `npm ls`.
2. `.github/workflows/package.yml` — new blocking guard after build: fails CI if `dist/` ever contains `adm-zip`/`image-size`/`onnxruntime-node`/`firefox-profile` markers, turning the documented dev-only claim into enforcement.
3. `.github/workflows/security.yml` — refreshed comments to name both unpatched roots, their pinned-latest state, and the new dist guard.

**Verification:** `npm audit` still reports the same 7 (4 moderate, 3 high), expected while both roots are unpatched upstream; 581/581 tests pass; eslint clean; chrome+firefox build succeeds; `lint:webext` 0 errors.