### PR TITLE
fix: await finalize path, preserve text and surface error on storage failure

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -195,6 +195,89 @@ function registerStreamJob(streamId, jobData) {
   scheduleStreamCleanup(streamId);
 }
 
+// Summaries that finished generating but could not be persisted (e.g. storage
+// quota). Kept in memory so the text survives for a retry even when every
+// storage write is rejecting. Bounded so a quota-stuck browser cannot grow it
+// without limit; entries are dropped oldest-first.
+export const pendingFinalizeRetries = new Map();
+const MAX_PENDING_FINALIZE_RETRIES = 10;
+
+export function preservePendingFinalize({ finalize, model, title, url, text }) {
+  const jobId = finalize?.jobId || finalize?.cacheKey || `${Date.now()}`;
+  if (pendingFinalizeRetries.has(jobId)) {
+    pendingFinalizeRetries.delete(jobId);
+  }
+  while (pendingFinalizeRetries.size >= MAX_PENDING_FINALIZE_RETRIES) {
+    const oldest = pendingFinalizeRetries.keys().next().value;
+    pendingFinalizeRetries.delete(oldest);
+  }
+  pendingFinalizeRetries.set(jobId, {
+    finalize,
+    model,
+    title,
+    url,
+    text,
+    savedAt: Date.now(),
+  });
+  return jobId;
+}
+
+export function takePendingFinalize(jobId) {
+  const entry = pendingFinalizeRetries.get(jobId);
+  if (entry) pendingFinalizeRetries.delete(jobId);
+  return entry || null;
+}
+
+export const FINALIZE_FAILED_MESSAGE =
+  "Couldn't save this summary (storage unavailable). The text above is preserved — try summarizing again.";
+
+function notifyFinalizeFailure({ finalize, error, streamId }) {
+  console.error("Failed to finalize summary:", error);
+  const jobId = finalize?.jobId || null;
+  const promptsCacheKey = finalize?.promptsCacheKey || null;
+  const stream = streamId ? activeStreams.get(streamId) : null;
+  if (stream) {
+    try {
+      broadcastToStream(stream, {
+        type: "error",
+        error: FINALIZE_FAILED_MESSAGE,
+        userFacing: true,
+        finalizeFailed: true,
+        jobId,
+        promptsCacheKey,
+      });
+    } catch {}
+  }
+  try {
+    chrome.runtime
+      .sendMessage({
+        type: "finalize-failed",
+        jobId,
+        promptsCacheKey,
+        error: FINALIZE_FAILED_MESSAGE,
+      })
+      .catch(() => {});
+  } catch {}
+  if (finalize?.notifyOnFinish) {
+    try {
+      notifyJobFailed(new UserFacingError(FINALIZE_FAILED_MESSAGE));
+    } catch {}
+  } else if (!stream) {
+    // No popup stream to show the banner and no completion notification
+    // requested: the notification is the only user-visible surface left.
+    // Background-initiated summaries always set notifyOnFinish, so this only
+    // fires for popup flows whose stream already went away.
+    try {
+      chrome.runtime
+        .sendMessage({
+          type: "model-progress",
+          progress: { progress: 0, text: FINALIZE_FAILED_MESSAGE },
+        })
+        .catch(() => {});
+    } catch {}
+  }
+}
+
 async function recordPopupSummaryStream(payload, streamId) {
   const finalize = payload?.finalize;
   if (!finalize?.jobId || finalize.tabId == null) return;
@@ -496,7 +579,14 @@ function createBufferedStream(streamId, { finalize, model, title, url }) {
     broadcastToStream(stream, msg);
     scheduleStreamCleanup(streamId);
     if (msg.type === "done") {
-      finalizeSummaryJob({ finalize, model, title, url, text: stream.text });
+      finalizeSummaryJob({
+        finalize,
+        model,
+        title,
+        url,
+        text: stream.text,
+        streamId,
+      }).catch((err) => console.error("Failed to finalize summary:", err));
     }
   };
 
@@ -1286,8 +1376,8 @@ async function runSuggestQuestionsJob(payload) {
   pendingSuggestKeys.add(promptsCacheKey);
   startKeepAlive();
 
+  let questions = [];
   try {
-    let questions = [];
     try {
       if (providerType === PROVIDERS.LLAMACPP) {
         const { llamaHost, llamaApiKey } = await getSettings();
@@ -1339,8 +1429,14 @@ async function runSuggestQuestionsJob(payload) {
     }
 
     // Generating the questions takes its own trip through the model, so the setting gets one more look before this write too.
-    if (persist && (await shouldPersist(persistUrl || url))) {
-      await chrome.storage.local.set({ [promptsCacheKey]: questions });
+    // A quota-full disk must not take down finalize: keep the in-memory
+    // questions for the popup even when the cache write rejects.
+    try {
+      if (persist && (await shouldPersist(persistUrl || url))) {
+        await chrome.storage.local.set({ [promptsCacheKey]: questions });
+      }
+    } catch (err) {
+      console.error("Failed to cache suggested questions:", err);
     }
     chrome.runtime
       .sendMessage({
@@ -1349,13 +1445,31 @@ async function runSuggestQuestionsJob(payload) {
         questions,
       })
       .catch(() => {});
+  } catch (err) {
+    console.error("Suggest-questions job failed:", err);
+    try {
+      chrome.runtime
+        .sendMessage({
+          type: "suggested-prompts-ready",
+          promptsCacheKey,
+          questions,
+        })
+        .catch(() => {});
+    } catch {}
   } finally {
     pendingSuggestKeys.delete(promptsCacheKey);
   }
 }
 
-async function finalizeSummaryJob({ finalize, model, title, url, text }) {
-  if (!finalize) return;
+export async function finalizeSummaryJob({
+  finalize,
+  model,
+  title,
+  url,
+  text,
+  streamId = null,
+}) {
+  if (!finalize) return { ok: true, persisted: false };
   // stream-finished text arrives via extension messaging and fans out into
   // cache/history/view-state: bound it at the trust boundary before use.
   if (typeof text === "string" && text.length > MAX_FINALIZE_TEXT_CHARS) {
@@ -1380,49 +1494,56 @@ async function finalizeSummaryJob({ finalize, model, title, url, text }) {
     translationEngine,
   } = finalize;
 
-  // `persist` is what was true when the job started. The write only happens if it is still true now, so turning history off mid-generation also excludes the summary that is running.
-  const persisted =
-    persist &&
-    (await persistSummaryIfAllowed(
-      persistUrl || url,
-      cacheKey,
-      promptsCacheKey,
-      text,
-      title,
-    ));
-
-  if (persisted || isSelection) {
-    await saveViewStateIfJobMatches(
-      tabId,
-      jobId,
-      {
-        view: "summaryView",
-        subview: "summary",
-        url: persistUrl || url,
-        streamId: null,
-        summaryText: text,
+  try {
+    // `persist` is what was true when the job started. The write only happens if it is still true now, so turning history off mid-generation also excludes the summary that is running.
+    const persisted =
+      persist &&
+      (await persistSummaryIfAllowed(
+        persistUrl || url,
+        cacheKey,
         promptsCacheKey,
-        summaryLanguage: language,
-        translationEngine,
-      },
-      "summarizing",
-    );
-  }
-  runSuggestQuestionsJob({
-    promptsCacheKey,
-    persist: persisted,
-    persistUrl: persistUrl || url,
-    providerType,
-    host,
-    title,
-    url,
-    summary: text,
-    model,
-    language,
-    translationEngine,
-  });
-  if (notifyOnFinish) {
-    notifyJobComplete({ title: sensitive ? "" : title, tabId, windowId });
+        text,
+        title,
+      ));
+
+    if (persisted || isSelection) {
+      await saveViewStateIfJobMatches(
+        tabId,
+        jobId,
+        {
+          view: "summaryView",
+          subview: "summary",
+          url: persistUrl || url,
+          streamId: null,
+          summaryText: text,
+          promptsCacheKey,
+          summaryLanguage: language,
+          translationEngine,
+        },
+        "summarizing",
+      );
+    }
+    runSuggestQuestionsJob({
+      promptsCacheKey,
+      persist: persisted,
+      persistUrl: persistUrl || url,
+      providerType,
+      host,
+      title,
+      url,
+      summary: text,
+      model,
+      language,
+      translationEngine,
+    }).catch((err) => console.error("Suggest-questions job failed:", err));
+    if (notifyOnFinish) {
+      notifyJobComplete({ title: sensitive ? "" : title, tabId, windowId });
+    }
+    return { ok: true, persisted: !!persisted };
+  } catch (err) {
+    preservePendingFinalize({ finalize, model, title, url, text });
+    notifyFinalizeFailure({ finalize, title, error: err, streamId });
+    return { ok: false, error: err };
   }
 }
 
@@ -1718,35 +1839,60 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.error) return false;
     (async () => {
       const streamId = message.streamId;
-      const registeredJob = streamId
-        ? registeredStreamJobs.get(streamId)
-        : null;
-      if (streamId) {
-        registeredStreamJobs.delete(streamId);
+      const fallbackTitle = message.title;
+      const fallbackUrl = message.url;
+      const fallbackText = message.text;
+      try {
+        const registeredJob = streamId
+          ? registeredStreamJobs.get(streamId)
+          : null;
+        if (streamId) {
+          registeredStreamJobs.delete(streamId);
+        }
+
+        const trustedFinalize =
+          registeredJob?.finalize ||
+          (message.finalize
+            ? await buildTrustedFinalize({
+                url: message.url,
+                title: message.title,
+                model: message.model,
+                finalize: message.finalize,
+              })
+            : null);
+        const model = registeredJob?.model || message.model;
+        const title = registeredJob?.title || message.title;
+        const url = registeredJob?.url || message.url;
+
+        await finalizeSummaryJob({
+          finalize: trustedFinalize,
+          model,
+          title,
+          url,
+          text: message.text,
+          streamId,
+        });
+      } catch (err) {
+        // buildTrustedFinalize can throw (e.g. storage read failure) before
+        // finalizeSummaryJob ever runs; preserve the text here so the same
+        // quota failure does not silently drop the finished summary.
+        try {
+          preservePendingFinalize({
+            finalize: message.finalize || null,
+            model: message.model,
+            title: fallbackTitle,
+            url: fallbackUrl,
+            text: fallbackText,
+          });
+        } catch {}
+        notifyFinalizeFailure({
+          finalize: message.finalize || null,
+          title: fallbackTitle,
+          error: err,
+          streamId,
+        });
       }
-
-      const trustedFinalize =
-        registeredJob?.finalize ||
-        (message.finalize
-          ? await buildTrustedFinalize({
-              url: message.url,
-              title: message.title,
-              model: message.model,
-              finalize: message.finalize,
-            })
-          : null);
-      const model = registeredJob?.model || message.model;
-      const title = registeredJob?.title || message.title;
-      const url = registeredJob?.url || message.url;
-
-      await finalizeSummaryJob({
-        finalize: trustedFinalize,
-        model,
-        title,
-        url,
-        text: message.text,
-      });
-    })();
+    })().catch((err) => console.error("stream-finished handler failed:", err));
     return false;
   }
 
@@ -1982,7 +2128,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             ...(promptsCacheKey ? { promptsCacheKey } : {}),
             providerType: getProviderType(settings),
             host: settings.ollamaHost,
-          });
+          }).catch((err) =>
+            console.error("Suggest-questions job failed:", err),
+          );
           sendResponse({ started: true });
           break;
         }

--- a/apogee-extension/tests/background/finalizeFailure.test.js
+++ b/apogee-extension/tests/background/finalizeFailure.test.js
@@ -1,0 +1,184 @@
+import test from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import { createExtensionApiMock } from "../helpers/extensionApiMock.js";
+
+// --- #265: unhandled async finalize can silently lose summaries ---
+//
+// `finalizeSummaryJob` used to be fire-and-forget from both
+// `createBufferedStream.finish` and the `stream-finished` handler, with no
+// `.catch`. A storage-quota throw inside `persistSummaryIfAllowed` (or the
+// suggest-questions cache write) became an unhandled rejection and the
+// finished summary was silently lost. Finalize must now never reject: it
+// preserves the buffered text for retry and surfaces a user-visible error.
+
+const { chrome } = createExtensionApiMock({
+  settings: {
+    saveHistory: true,
+    responseFormat: "bullets",
+    summaryLanguage: "auto",
+    customInstructions: "",
+    translationEngine: "opus",
+    provider: "webllm",
+    webllmModel: "Qwen2.5-0.5B-Instruct-q4f16_1-MLC",
+    ollamaHost: "http://127.0.0.1:11434",
+  },
+});
+
+const sentMessages = [];
+const notifications = [];
+let quotaFailure = true;
+
+const backingSet = chrome.storage.local.set.bind(chrome.storage.local);
+chrome.storage.local.set = async (obj) => {
+  if (quotaFailure && Object.keys(obj).some((k) => k.startsWith("summary:"))) {
+    throw new Error("Quota exceeded");
+  }
+  return backingSet(obj);
+};
+
+const backingSend = chrome.runtime.sendMessage.bind(chrome.runtime);
+chrome.runtime.sendMessage = async (msg) => {
+  sentMessages.push(msg);
+  try {
+    return await backingSend(msg);
+  } catch {
+    return undefined;
+  }
+};
+
+chrome.alarms = {
+  create: () => {},
+  clear: async () => {},
+  onAlarm: { addListener: () => {} },
+};
+chrome.notifications = {
+  create: async (id, opts) => {
+    notifications.push({ id, opts });
+    return id;
+  },
+  onClicked: { addListener: () => {} },
+  onClosed: { addListener: () => {} },
+};
+chrome.action = {};
+
+globalThis.chrome = chrome;
+
+const {
+  finalizeSummaryJob,
+  pendingFinalizeRetries,
+  takePendingFinalize,
+  FINALIZE_FAILED_MESSAGE,
+} = await import("../../background/service-worker.js");
+
+function makeFinalize(overrides = {}) {
+  return {
+    cacheKey: "summary:test-quota-key",
+    promptsCacheKey: "suggested-prompts:test-quota-key",
+    persist: true,
+    persistUrl: "https://example.com/article",
+    isSelection: false,
+    providerType: "webllm",
+    host: "http://127.0.0.1:11434",
+    notifyOnFinish: false,
+    sensitive: false,
+    tabId: 101,
+    jobId: "job-quota-1",
+    windowId: 1,
+    language: "auto",
+    translationEngine: "opus",
+    ...overrides,
+  };
+}
+
+test("quota throw during finalize never rejects and preserves text for retry (#265)", async () => {
+  pendingFinalizeRetries.clear();
+  sentMessages.length = 0;
+  quotaFailure = true;
+
+  const text = "Finished summary that must not be lost.";
+  let result;
+  try {
+    result = await finalizeSummaryJob({
+      finalize: makeFinalize(),
+      model: "model-x",
+      title: "Example",
+      url: "https://example.com/article",
+      text,
+    });
+  } catch (err) {
+    assert.fail(
+      `finalizeSummaryJob must not throw, but threw: ${err?.stack || err}`,
+    );
+  }
+
+  assert.strictEqual(result?.ok, false, "result reports the failure");
+  assert.ok(result?.error instanceof Error, "result carries the quota error");
+
+  const pending = pendingFinalizeRetries.get("job-quota-1");
+  assert.ok(pending, "buffered text is preserved for retry");
+  assert.strictEqual(
+    pending.text,
+    text,
+    "preserved text matches the finished summary",
+  );
+  assert.strictEqual(pending.title, "Example");
+
+  const failed = sentMessages.find((m) => m?.type === "finalize-failed");
+  assert.ok(failed, "a user-visible finalize-failed message is emitted");
+  assert.strictEqual(failed.jobId, "job-quota-1");
+  assert.strictEqual(failed.error, FINALIZE_FAILED_MESSAGE);
+
+  // The pending entry is retrievable for a retry and cleared on take.
+  const taken = takePendingFinalize("job-quota-1");
+  assert.strictEqual(taken?.text, text);
+  assert.strictEqual(pendingFinalizeRetries.has("job-quota-1"), false);
+});
+
+test("finalize succeeds without preserving when storage works (#265)", async () => {
+  pendingFinalizeRetries.clear();
+  sentMessages.length = 0;
+  quotaFailure = false;
+
+  const result = await finalizeSummaryJob({
+    finalize: makeFinalize({ jobId: "job-ok-1" }),
+    model: "model-x",
+    title: "Example",
+    url: "https://example.com/article",
+    text: "summarized body",
+  });
+
+  assert.strictEqual(result?.ok, true, "happy path still resolves ok");
+  assert.strictEqual(
+    pendingFinalizeRetries.has("job-ok-1"),
+    false,
+    "nothing preserved on success",
+  );
+});
+
+test("fire-and-forget finalize call sites are awaited with catch handlers (#265)", () => {
+  const swCode = fs.readFileSync(
+    new URL("../../background/service-worker.js", import.meta.url),
+    "utf-8",
+  );
+  assert.ok(
+    swCode.includes("finalizeSummaryJob({"),
+    "finalizeSummaryJob call sites exist",
+  );
+  assert.ok(
+    swCode.includes("}).catch((err) => console.error("),
+    "fire-and-forget finalize/suggest jobs attach .catch",
+  );
+  assert.ok(
+    swCode.includes("stream-finished handler failed:"),
+    "stream-finished IIFE has an outer .catch",
+  );
+  assert.ok(
+    swCode.includes("finalize-failed"),
+    "finalize failures surface a user-visible message",
+  );
+  assert.ok(
+    swCode.includes("preservePendingFinalize("),
+    "failed finalizes preserve buffered text",
+  );
+});


### PR DESCRIPTION
Fixes #265.

The `stream-finished` handler and `createBufferedStream.finish` invoked `finalizeSummaryJob` fire-and-forget with no `.catch`, so a storage-quota throw inside `buildTrustedFinalize`/`finalizeSummaryJob` (or the suggest-questions cache write) became an unhandled rejection and the finished summary was silently lost.

Changes (apogee-extension/background/service-worker.js):
- `finalizeSummaryJob` never rejects: persist/view-state writes are wrapped in try/catch; on failure the buffered text is preserved in a bounded in-memory `pendingFinalizeRetries` map (`preserve/takePendingFinalize`) and a user-visible `finalize-failed` message is emitted (stream broadcast + runtime message + failure notification when `notifyOnFinish`).
- `runSuggestQuestionsJob` cache write isolated in its own try/catch so quota failure still delivers in-memory questions; outer catch safety net added.
- Fire-and-forget call sites now attach `.catch`: buffered-stream finish, `suggest-questions-bg`, and finalize's internal suggest call; `stream-finished` IIFE has inner try/catch (covers `buildTrustedFinalize` throws) plus outer `.catch`.

Tests:
- New `tests/background/finalizeFailure.test.js`: quota-throw during finalize resolves `{ok:false}` without rejecting, preserves text for retry, emits `finalize-failed`; happy path preserves nothing; static check guards the `.catch` handlers.
- Full suite: 589 pass. ESLint and Prettier clean.