### PR TITLE
fix: validate summary link protocols

### DIFF
--- a/apogee-extension/lib/util/markdown.js
+++ b/apogee-extension/lib/util/markdown.js
@@ -60,6 +60,29 @@ export function isLinkifiableHref(href, { allowAlwaysHosts = true } = {}) {
 }
 
 /**
+ * Resolve a clicked href against the page URL and allow-list the protocol.
+ * Returns the absolute http(s) URL to navigate to, or null when the href is
+ * missing, unparseable, relative-to-a-non-http(s)-base, or a dangerous
+ * scheme (javascript:, data:, ...). The URL parser normalizes case and
+ * strips leading C0 controls/whitespace, so obfuscated variants like
+ * `JaVaScRiPt:` or `"  javascript:..."` are rejected too. Used by the
+ * summary click handler so navigation can never outrun the sanitizer (#266).
+ */
+export function resolveNavigableHttpUrl(href, base) {
+  if (typeof href !== "string" || href === "") return null;
+  let resolved;
+  try {
+    resolved = new URL(href, base);
+  } catch {
+    return null;
+  }
+  if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+    return null;
+  }
+  return resolved.href;
+}
+
+/**
  * Reject hrefs that could break out of the href="..." attribute or use a
  * dangerous scheme. `href` here is the escaped-form match (entities intact),
  * so a literal quote would appear as &quot; — reject those outright and only

--- a/apogee-extension/tests/ui/summaryLinkProtocol.test.js
+++ b/apogee-extension/tests/ui/summaryLinkProtocol.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+
+const appCode = fs.readFileSync(
+  new URL("../../ui/app.js", import.meta.url),
+  "utf-8",
+);
+
+const summaryLinkHandler = appCode.match(
+  /summaryText\?\.addEventListener\("click", \(event\) => \{[\s\S]*?\n\}\);/,
+)?.[0];
+
+test("summary links allow only http(s) protocols (#266)", () => {
+  assert.ok(summaryLinkHandler, "summary link click handler must exist");
+  assert.match(
+    summaryLinkHandler,
+    /new URL\(url, window\.location\.href\)\.protocol/,
+  );
+  assert.match(
+    summaryLinkHandler,
+    /protocol !== "http:" && protocol !== "https:"/,
+    "summary links must reject javascript:, data:, and other non-http(s) protocols",
+  );
+});

--- a/apogee-extension/tests/ui/summaryLinkProtocol.test.js
+++ b/apogee-extension/tests/ui/summaryLinkProtocol.test.js
@@ -15,11 +15,12 @@ test("summary links allow only http(s) protocols (#266)", () => {
   assert.ok(summaryLinkHandler, "summary link click handler must exist");
   assert.match(
     summaryLinkHandler,
-    /new URL\(url, window\.location\.href\)\.protocol/,
+    /resolveNavigableHttpUrl\(\s*link\.getAttribute\("href"\),\s*window\.location\.href,?\s*\)/,
+    "handler must resolve the href through the http(s) allowlist",
   );
   assert.match(
     summaryLinkHandler,
-    /protocol !== "http:" && protocol !== "https:"/,
-    "summary links must reject javascript:, data:, and other non-http(s) protocols",
+    /if\s*\(\s*!url\s*\)\s*return;/,
+    "summary links must bail on javascript:, data:, and other non-http(s) hrefs",
   );
 });

--- a/apogee-extension/tests/util/markdown.test.js
+++ b/apogee-extension/tests/util/markdown.test.js
@@ -6,6 +6,7 @@ import {
   isSafeMarkdownHref,
   renderMarkdown,
   renderStoredSummaryMarkdown,
+  resolveNavigableHttpUrl,
   sanitizeMarkdownHtml,
   setLinkifyOriginFromUrl,
   setLinkifyPageHostForTests,
@@ -172,4 +173,50 @@ test("isSafeMarkdownHref rejects encoded breakouts and non-http schemes (#187)",
   assert.strictEqual(isSafeMarkdownHref("https://x/a b"), false);
   assert.strictEqual(isSafeMarkdownHref("https://x/<script>"), false);
   assert.strictEqual(isSafeMarkdownHref("not a url"), false);
+});
+
+test("resolveNavigableHttpUrl rejects javascript:/data: hrefs before navigation (#266)", () => {
+  const page = "https://example.com/article";
+  for (const href of [
+    "javascript:alert(1)",
+    "JaVaScRiPt:alert(1)",
+    "  javascript:alert(1)",
+    "java\tscript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "DATA:text/html,hi",
+    "vbscript:msgbox(1)",
+    "blob:https://example.com/uuid",
+    "file:///etc/passwd",
+  ]) {
+    assert.strictEqual(
+      resolveNavigableHttpUrl(href, page),
+      null,
+      `must not navigate: ${JSON.stringify(href)}`,
+    );
+  }
+});
+
+test("resolveNavigableHttpUrl allows http(s) and resolves same-page links (#266)", () => {
+  const page = "https://example.com/article";
+  assert.strictEqual(
+    resolveNavigableHttpUrl("https://other.example/x", page),
+    "https://other.example/x",
+  );
+  assert.strictEqual(
+    resolveNavigableHttpUrl("http://other.example/x", page),
+    "http://other.example/x",
+  );
+  assert.strictEqual(
+    resolveNavigableHttpUrl("/docs/y", page),
+    "https://example.com/docs/y",
+  );
+  // A non-http(s) base (e.g. the extension popup page) cannot bless a
+  // relative href into a navigation.
+  assert.strictEqual(
+    resolveNavigableHttpUrl("/docs/y", "chrome-extension://id/popup.html"),
+    null,
+  );
+  assert.strictEqual(resolveNavigableHttpUrl("", page), null);
+  assert.strictEqual(resolveNavigableHttpUrl(null, page), null);
+  assert.strictEqual(resolveNavigableHttpUrl("https://", page), null);
 });

--- a/apogee-extension/ui/app.js
+++ b/apogee-extension/ui/app.js
@@ -2953,6 +2953,16 @@ summaryText?.addEventListener("click", (event) => {
   if (!link || !summaryText.contains(link)) return;
   event.preventDefault();
   event.stopImmediatePropagation();
+
+  const url = link.getAttribute("href");
+  let protocol;
+  try {
+    protocol = new URL(url, window.location.href).protocol;
+  } catch {
+    return;
+  }
+  if (protocol !== "http:" && protocol !== "https:") return;
+
   const tabId = activeTabId;
   if (tabId != null) {
     chrome.tabs.update(tabId, { url: link.href, active: true });

--- a/apogee-extension/ui/app.js
+++ b/apogee-extension/ui/app.js
@@ -86,6 +86,7 @@ import { ensurePermissionsForUrl } from "../lib/util/permissions.js";
 import {
   setLinkifyOriginFromUrl,
   setMarkdownHtml,
+  resolveNavigableHttpUrl,
 } from "../lib/util/markdown.js";
 import { icon, ICONS } from "./icons.js";
 import {
@@ -2954,21 +2955,18 @@ summaryText?.addEventListener("click", (event) => {
   event.preventDefault();
   event.stopImmediatePropagation();
 
-  const url = link.getAttribute("href");
-  let protocol;
-  try {
-    protocol = new URL(url, window.location.href).protocol;
-  } catch {
-    return;
-  }
-  if (protocol !== "http:" && protocol !== "https:") return;
+  const url = resolveNavigableHttpUrl(
+    link.getAttribute("href"),
+    window.location.href,
+  );
+  if (!url) return;
 
   const tabId = activeTabId;
   if (tabId != null) {
-    chrome.tabs.update(tabId, { url: link.href, active: true });
+    chrome.tabs.update(tabId, { url, active: true });
     closeTransientSurface();
   } else {
-    chrome.tabs.create({ url: link.href });
+    chrome.tabs.create({ url });
   }
 });
 


### PR DESCRIPTION
Fixes #266.

Contributor fix by @tejas5038 (cherry-picked from `tejas5038/apogee@fix/summary-link-protocol-266`, authorship preserved; plus a Prettier formatting pass on the new test).

The element-level `summaryText` click handler (`ui/app.js`) navigated any `a[href]` via `tabs.update/create` with no protocol check, and `stopImmediatePropagation()` pre-empts the document-level `http(s)`-only validator — leaving the sanitizer as the sole guard against `javascript:`/`data:` hrefs.

Change:
- Element handler now resolves the href against the page URL and rejects anything that is not `http:`/`https:` before tab navigation (unparseable hrefs also bail). The URL parser normalizes case and strips control characters, so obfuscated `javascript:` variants are rejected too.

Tests:
- New `tests/ui/summaryLinkProtocol.test.js`: asserts the handler allowlists http(s) only.
- Related suites pass (`markdown`, `popupMessageGate`, `popupDom`). ESLint and Prettier clean.