### PR TITLE
fix: stop triple-buffering 50MB file uploads, cap expanded text

### DIFF
--- a/apogee-extension/lib/extract/fileLimits.js
+++ b/apogee-extension/lib/extract/fileLimits.js
@@ -64,3 +64,108 @@ export function truncatePastedText(text) {
     truncated: true,
   };
 }
+
+// Expanded-text working ceiling (#267). PDF/DOCX extraction inflates a 50 MB
+// upload into megabytes of text; the popup cannot hold the full expansion
+// plus prompt chunks, and summarizeCustomContent truncates to MAX_PASTED_CHARS
+// downstream anyway. Capping at the same size at the extraction site bounds
+// peak memory and keeps one user-visible truncation note instead of two.
+// The truncated output is sized to fit back through truncatePastedText
+// untouched (room is reserved for the note), so the choke point stays quiet.
+export const MAX_EXTRACTED_TEXT_CHARS = MAX_PASTED_CHARS;
+
+// Cut a string without leaving a dangling lead surrogate at the boundary,
+// so truncating emoji-heavy text never emits a broken character.
+function sliceOnCharBoundary(text, maxLength) {
+  let head = text.slice(0, Math.max(0, maxLength));
+  if (/[\uD800-\uDBFF]$/.test(head)) head = head.slice(0, -1);
+  return head;
+}
+
+export function truncateExtractedText(text, label = "file") {
+  const clean = (text || "").trim();
+  if (clean.length <= MAX_EXTRACTED_TEXT_CHARS)
+    return { text: clean, truncated: false };
+  const note =
+    `[...${label} content truncated to the first ` +
+    `${MAX_EXTRACTED_TEXT_CHARS} characters...]`;
+  const head = sliceOnCharBoundary(
+    clean,
+    MAX_EXTRACTED_TEXT_CHARS - note.length - 2,
+  ).trimEnd();
+  return { text: `${head}\n\n${note}`, truncated: true };
+}
+
+// Slice size for incremental base64 encoding below. Must stay a multiple of 3
+// so each slice encodes to a whole number of base64 quanta and slices can be
+// encoded independently without corrupting boundary bytes.
+export const BASE64_SLICE_BYTES = 0x9000;
+
+/**
+ * Encode bytes to base64 one slice at a time (#267). The naive
+ * binary-string-then-btoa pattern holds the input bytes, a full-size binary
+ * string, and the full base64 output concurrently (~3x a 50 MB upload in
+ * UTF-16 strings). Here only the input, the growing output, and one 36 KiB
+ * slice are live at once; each slice's binary string is released per
+ * iteration.
+ */
+export function bytesToBase64(bytes) {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += BASE64_SLICE_BYTES) {
+    const slice = bytes.subarray(i, i + BASE64_SLICE_BYTES);
+    let binary = "";
+    const STEP = 0x8000;
+    for (let j = 0; j < slice.length; j += STEP) {
+      binary += String.fromCharCode.apply(null, slice.subarray(j, j + STEP));
+    }
+    out += btoa(binary);
+  }
+  return out;
+}
+
+/**
+ * Read at most maxChars+1 characters of a user-supplied file (#267).
+ * file.text() on a 50 MB upload materializes the whole string before the
+ * caller can truncate it; streaming slices through a TextDecoder and
+ * cancelling past the cap keeps peak memory proportional to the cap, not the
+ * file. Returns { text, truncated } with the same note convention as
+ * truncatePastedText. UTF-8 note: every character costs >= 1 byte, so a file
+ * whose byte size fits the cap cannot exceed it and is read whole.
+ */
+export async function readTextHead(file, maxChars = MAX_PASTED_CHARS) {
+  if (
+    typeof file.size === "number" &&
+    file.size <= maxChars &&
+    typeof file.text === "function"
+  ) {
+    return truncatePastedText(await file.text());
+  }
+  const reader = file.stream().getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  let truncated = false;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+      if (text.length > maxChars) {
+        truncated = true;
+        try {
+          await reader.cancel();
+        } catch {}
+        break;
+      }
+    }
+    if (!truncated) text += decoder.decode();
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {}
+  }
+  if (!truncated) return truncatePastedText(text);
+  const clean = text.trim();
+  const note = `[...file content truncated to the first ${maxChars} characters...]`;
+  const head = sliceOnCharBoundary(clean, maxChars - note.length - 2).trimEnd();
+  return { text: `${head}\n\n${note}`, truncated: true };
+}

--- a/apogee-extension/lib/extract/pageExtraction.js
+++ b/apogee-extension/lib/extract/pageExtraction.js
@@ -127,12 +127,25 @@ export async function extractPdfContent(tab) {
             `for in-extension processing.`,
         );
       }
-      let binary = "";
-      const CHUNK = 0x8000;
+      let base64 = "";
+      // Encode slice-by-slice (#267): a single binary string for the whole
+      // file would sit next to the bytes and the base64 output (~3x the PDF
+      // in memory). The slice size stays a multiple of 3 so each slice maps
+      // to whole base64 quanta and boundary bytes are never corrupted.
+      const CHUNK = 0x9000;
       for (let i = 0; i < bytes.length; i += CHUNK) {
-        binary += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK));
+        const slice = bytes.subarray(i, i + CHUNK);
+        let binary = "";
+        const STEP = 0x8000;
+        for (let j = 0; j < slice.length; j += STEP) {
+          binary += String.fromCharCode.apply(
+            null,
+            slice.subarray(j, j + STEP),
+          );
+        }
+        base64 += btoa(binary);
       }
-      return btoa(binary);
+      return base64;
     },
     args: [MAX_UPLOAD_FILE_BYTES],
   });

--- a/apogee-extension/lib/extract/pdfExtract.js
+++ b/apogee-extension/lib/extract/pdfExtract.js
@@ -1,5 +1,5 @@
 import { UserFacingError } from "../util/userError.js";
-import { MAX_PDF_TEXT_CHARS } from "./fileLimits.js";
+import { MAX_PDF_TEXT_CHARS, truncateExtractedText } from "./fileLimits.js";
 
 class PdfExtractionError extends UserFacingError {}
 
@@ -16,15 +16,33 @@ async function getPdfjs() {
 }
 
 function base64ToBytes(base64) {
-  const binary = atob(base64);
+  let binary = atob(base64);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
     bytes[i] = binary.charCodeAt(i);
   }
+  // Intentional release: drop the transient string before the heavy parse.
+  // eslint-disable-next-line no-useless-assignment
+  binary = null;
   return bytes;
 }
 
-export async function extractPdfText(pdfBase64) {
+/**
+ * Parse PDF text straight from bytes (#267). The popup upload path used to
+ * hold arrayBuffer + binary string + base64 concurrently and then decode the
+ * base64 back to bytes inside pdf.js — ~3x the file in memory. Callers that
+ * already have bytes use this and skip both transient strings entirely.
+ *
+ * options.maxChars bounds the *expanded* text: once a page pushes past it,
+ * parsing stops early (remaining pages are never read) and the result carries
+ * the user-visible truncation note. The MAX_PDF_TEXT_CHARS backstop still
+ * throws on pathological inflation. Defaults preserve the legacy behavior
+ * (service-worker tab path), which caps only via the backstop.
+ */
+export async function extractPdfTextFromBytes(
+  bytes,
+  { maxChars = Infinity, label = "PDF" } = {},
+) {
   const {
     getDocument,
     InvalidPDFException,
@@ -33,7 +51,7 @@ export async function extractPdfText(pdfBase64) {
   } = await getPdfjs();
 
   const loadingTask = getDocument({
-    data: base64ToBytes(pdfBase64),
+    data: bytes,
     isEvalSupported: false,
     useSystemFonts: true,
     verbosity: VerbosityLevel.ERRORS,
@@ -54,6 +72,7 @@ export async function extractPdfText(pdfBase64) {
 
   try {
     let text = "";
+    let truncated = false;
     for (let pageNum = 1; pageNum <= doc.numPages; pageNum++) {
       const page = await doc.getPage(pageNum);
       const content = await page.getTextContent();
@@ -64,11 +83,21 @@ export async function extractPdfText(pdfBase64) {
       }
       addition += "\n";
       text = appendPdfText(text, addition);
+      if (text.length > maxChars) {
+        text = truncateExtractedText(text, label).text;
+        truncated = true;
+        break;
+      }
     }
-    return text;
+    return { text, truncated };
   } finally {
     await loadingTask.destroy();
   }
+}
+
+export async function extractPdfText(pdfBase64) {
+  const { text } = await extractPdfTextFromBytes(base64ToBytes(pdfBase64));
+  return text;
 }
 
 /**

--- a/apogee-extension/tests/extract/fileLimits.test.js
+++ b/apogee-extension/tests/extract/fileLimits.test.js
@@ -2,13 +2,18 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  BASE64_SLICE_BYTES,
   MAX_BILIBILI_SUBTITLE_CHARS,
   MAX_BILIBILI_SUBTITLE_SEGMENTS,
+  MAX_EXTRACTED_TEXT_CHARS,
   MAX_FINALIZE_TEXT_CHARS,
   MAX_PASTED_CHARS,
   MAX_UPLOAD_FILE_BYTES,
   MAX_UPLOAD_FILE_MB,
   assertUploadSizeOk,
+  bytesToBase64,
+  readTextHead,
+  truncateExtractedText,
   truncatePastedText,
 } from "../../lib/extract/fileLimits.js";
 
@@ -61,4 +66,142 @@ test("finished-summary backstop is a generous fixed ceiling", () => {
 test("bilibili subtitle ceilings bound segments and characters", () => {
   assert.equal(MAX_BILIBILI_SUBTITLE_SEGMENTS, 5000);
   assert.equal(MAX_BILIBILI_SUBTITLE_CHARS, 500 * 1024);
+});
+
+test("extracted-text cap shares the pasted working ceiling (#267)", () => {
+  assert.equal(MAX_EXTRACTED_TEXT_CHARS, MAX_PASTED_CHARS);
+});
+
+test("truncateExtractedText passes short text through untouched (#267)", () => {
+  const { text, truncated } = truncateExtractedText("  hello  ", "PDF");
+  assert.equal(text, "hello");
+  assert.equal(truncated, false);
+  const atCap = truncateExtractedText(
+    "x".repeat(MAX_EXTRACTED_TEXT_CHARS),
+    "PDF",
+  );
+  assert.equal(atCap.truncated, false);
+  assert.equal(atCap.text.length, MAX_EXTRACTED_TEXT_CHARS);
+});
+
+test("truncateExtractedText truncates with a file note past the ceiling (#267)", () => {
+  const { text, truncated } = truncateExtractedText(
+    "y".repeat(MAX_EXTRACTED_TEXT_CHARS + 1000),
+    "PDF",
+  );
+  assert.equal(truncated, true);
+  assert.ok(text.startsWith("y".repeat(100)));
+  assert.match(text, /\[\.\.\.PDF content truncated/);
+  assert.match(text, new RegExp(`${MAX_EXTRACTED_TEXT_CHARS}`));
+});
+
+test("truncated extraction output fits back through the pasted choke point (#267)", () => {
+  const { text } = truncateExtractedText(
+    "z".repeat(MAX_EXTRACTED_TEXT_CHARS + 5000),
+    "DOCX file",
+  );
+  // summarizeCustomContent re-applies truncatePastedText; the early cap must
+  // not trigger a second truncation note downstream.
+  const downstream = truncatePastedText(text);
+  assert.equal(downstream.truncated, false);
+  assert.equal(downstream.text, text);
+});
+
+function pseudoRandomBytes(length, seed = 0x12345678) {
+  const out = new Uint8Array(length);
+  let state = seed >>> 0;
+  for (let i = 0; i < length; i++) {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    out[i] = (state >>> 24) & 0xff;
+  }
+  return out;
+}
+
+test("bytesToBase64 slice size stays 3-byte aligned (#267)", () => {
+  assert.equal(BASE64_SLICE_BYTES % 3, 0);
+});
+
+test("bytesToBase64 round-trips across slice boundaries (#267)", () => {
+  for (const length of [
+    0,
+    1,
+    2,
+    3,
+    5,
+    0x8000,
+    BASE64_SLICE_BYTES - 1,
+    BASE64_SLICE_BYTES,
+    BASE64_SLICE_BYTES + 1,
+    BASE64_SLICE_BYTES * 2 + 7,
+  ]) {
+    const bytes = pseudoRandomBytes(length);
+    const expected = Buffer.from(bytes).toString("base64");
+    assert.equal(bytesToBase64(bytes), expected, `length ${length}`);
+  }
+});
+
+test("bytesToBase64 handles a multi-slice large-file payload (#267)", () => {
+  // ~200 KiB of adversarial bytes spans several slices without ever holding
+  // a full-size binary string next to the output.
+  const bytes = pseudoRandomBytes(BASE64_SLICE_BYTES * 5 + 12345);
+  const decoded = Buffer.from(bytesToBase64(bytes), "base64");
+  assert.deepEqual(new Uint8Array(decoded), bytes);
+});
+
+test("readTextHead reads small files whole without truncating (#267)", async () => {
+  const file = new Blob(["  hello world  "]);
+  const { text, truncated } = await readTextHead(file);
+  assert.equal(truncated, false);
+  assert.equal(text, "hello world");
+});
+
+test("readTextHead caps a large file with a user-visible note (#267)", async () => {
+  // Oversized upload: only the head may materialize, never the whole string.
+  const file = new Blob(["a".repeat(MAX_PASTED_CHARS + 50_000)]);
+  const { text, truncated } = await readTextHead(file);
+  assert.equal(truncated, true);
+  assert.ok(text.length <= MAX_PASTED_CHARS);
+  assert.match(text, /\[\.\.\.file content truncated/);
+  assert.equal(truncatePastedText(text).truncated, false);
+});
+
+test("readTextHead counts characters, not bytes, for multibyte text (#267)", async () => {
+  // "é" costs 2 bytes in UTF-8: byte size exceeds the cap while the
+  // character count sits exactly on it, so nothing is truncated.
+  const file = new Blob(["é".repeat(MAX_PASTED_CHARS)]);
+  assert.ok(file.size > MAX_PASTED_CHARS);
+  const { text, truncated } = await readTextHead(file);
+  assert.equal(truncated, false);
+  assert.equal(text.length, MAX_PASTED_CHARS);
+});
+
+test("readTextHead never splits surrogate pairs at the cap (#267)", async () => {
+  const file = new Blob(["😀".repeat(MAX_PASTED_CHARS)]);
+  const { text, truncated } = await readTextHead(file, 100);
+  assert.equal(truncated, true);
+  assert.match(text, /\[\.\.\.file content truncated/);
+  const head = text.split("\n\n")[0];
+  // Every code point survived whole: no split surrogate or replacement char.
+  for (const char of head) {
+    assert.equal(char.length, 2);
+    assert.notEqual(char, "�");
+  }
+});
+
+test("readTextHead streams when file size is unknown (#267)", async () => {
+  const blob = new Blob(["q".repeat(5000)]);
+  const unknownSize = {
+    stream: () => blob.stream(),
+  };
+  const { text, truncated } = await readTextHead(unknownSize, 100);
+  assert.equal(truncated, true);
+  assert.match(
+    text,
+    /\[\.\.\.file content truncated to the first 100 characters/,
+  );
+  const small = { stream: () => new Blob(["ok"]).stream() };
+  assert.deepEqual(await readTextHead(small, 100), {
+    text: "ok",
+    truncated: false,
+  });
 });

--- a/apogee-extension/ui/app.js
+++ b/apogee-extension/ui/app.js
@@ -76,6 +76,9 @@ import {
 } from "../lib/extract/pageExtraction.js";
 import {
   assertUploadSizeOk,
+  MAX_EXTRACTED_TEXT_CHARS,
+  readTextHead,
+  truncateExtractedText,
   truncatePastedText,
 } from "../lib/extract/fileLimits.js";
 import {
@@ -2402,45 +2405,78 @@ const fileUploadInput = document.getElementById("fileUploadInput");
 
 async function summarizeFile(file) {
   // Same ceiling as the tab-PDF path, checked before any read so an
-  // oversized file never becomes several in-memory copies (arrayBuffer +
-  // base64 + binary string) on the way in.
+  // oversized file never enters memory (#184). The PDF branch below parses
+  // straight from bytes (#267): the old arrayBuffer -> binary string ->
+  // base64 -> decode round-trip held ~3x the file concurrently.
   const lowerName = file.name.toLowerCase();
-  assertUploadSizeOk(
-    file.size,
-    lowerName.endsWith(".pdf")
-      ? "PDF"
-      : lowerName.endsWith(".docx")
-        ? "DOCX file"
-        : "file",
-  );
+  const label = lowerName.endsWith(".pdf")
+    ? "PDF"
+    : lowerName.endsWith(".docx")
+      ? "DOCX file"
+      : "file";
+  assertUploadSizeOk(file.size, label);
   let text;
+  let truncationNotice = "";
   if (lowerName.endsWith(".pdf")) {
-    const arrayBuffer = await file.arrayBuffer();
-    const bytes = new Uint8Array(arrayBuffer);
-    let binary = "";
-    const chunkSize = 0x8000;
-    for (let i = 0; i < bytes.byteLength; i += chunkSize) {
-      binary += String.fromCharCode.apply(
-        null,
-        bytes.subarray(i, i + chunkSize),
-      );
+    let arrayBuffer = await file.arrayBuffer();
+    try {
+      // file.size can be missing or wrong; re-check the actual bytes.
+      assertUploadSizeOk(arrayBuffer.byteLength, "PDF");
+      const { extractPdfTextFromBytes } =
+        await import("../lib/extract/pdfExtract.js");
+      let bytes = new Uint8Array(arrayBuffer);
+      try {
+        // maxChars stops page parsing early with a user-visible note, so a
+        // pathological expansion never becomes a multi-MB string in the popup.
+        const result = await extractPdfTextFromBytes(bytes, {
+          maxChars: MAX_EXTRACTED_TEXT_CHARS,
+          label: "PDF",
+        });
+        text = result.text;
+        if (result.truncated) {
+          truncationNotice = `PDF content exceeded the text limit and was truncated to the first ${MAX_EXTRACTED_TEXT_CHARS} characters.`;
+        }
+      } finally {
+        // Intentional release: drop the view so the buffer can GC early.
+        bytes = null;
+      }
+    } finally {
+      // eslint-disable-next-line no-useless-assignment
+      arrayBuffer = null;
     }
-    const base64 = btoa(binary);
-    const { extractPdfText } = await import("../lib/extract/pdfExtract.js");
-    text = await extractPdfText(base64);
   } else if (lowerName.endsWith(".docx")) {
-    const { extractDocxText } = await import("../lib/extract/docxExtract.js");
-    text = await extractDocxText(await file.arrayBuffer());
+    let arrayBuffer = await file.arrayBuffer();
+    try {
+      assertUploadSizeOk(arrayBuffer.byteLength, "DOCX file");
+      const { extractDocxText } = await import("../lib/extract/docxExtract.js");
+      const capped = truncateExtractedText(
+        await extractDocxText(arrayBuffer),
+        "DOCX file",
+      );
+      text = capped.text;
+      if (capped.truncated) {
+        truncationNotice = `DOCX content exceeded the text limit and was truncated to the first ${MAX_EXTRACTED_TEXT_CHARS} characters.`;
+      }
+    } finally {
+      // Intentional release: drop the buffer so it can GC before summarize.
+      // eslint-disable-next-line no-useless-assignment
+      arrayBuffer = null;
+    }
   } else {
-    // Plain-text branch (txt/md/json/html): file.size bounds the upload but
-    // the post-read string was unbounded, so cap it before it fans out (#211).
+    // Plain-text branch (txt/md/json/html): stream only the head of the file
+    // so a 50 MB upload never materializes as a 50 MB string (#267).
     // summarizeCustomContent re-applies the same cap as a choke point.
-    text = truncatePastedText(await file.text()).text;
+    const head = await readTextHead(file);
+    text = head.text;
+    if (head.truncated) {
+      truncationNotice = `File content exceeded the text limit and was truncated to the first ${MAX_EXTRACTED_TEXT_CHARS} characters.`;
+    }
   }
 
   if (!text || !text.trim()) {
     throw new Error("The file contains no readable text.");
   }
+  if (truncationNotice) announce(truncationNotice);
   await summarizeCustomContent(file.name, text.trim());
 }
 


### PR DESCRIPTION
Fixes #267.

## Problem
- `ui/app.js` upload path held arrayBuffer plus binary string plus base64 at once for 50 MB files; size check covered only `file.size`, not expanded text.
- 50 MB upload cap and 25 M-char PDF text cap still let expanded text OOM the popup.

## Changes
- PDF uploads parse straight from bytes via new `extractPdfTextFromBytes`; buffers released right after parsing; actual byte length re-checked.
- Text uploads stream only the file head (`readTextHead`) instead of materializing the full string.
- Expanded PDF, DOCX, and text output capped at `MAX_EXTRACTED_TEXT_CHARS` with a user-visible truncation note; output sized to pass the downstream pasted-text choke point without a second note.
- Tab-PDF encoder emits base64 slice by slice (3-byte aligned).
- 10 new large-file memory-path tests in `tests/extract/fileLimits.test.js`.

## Verification
- Full suite: 604 pass, 0 fail.
- ESLint and Prettier clean.