### PR TITLE
fix: per-engine inference locks with timeout, keep healthy engine on transient error

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -810,85 +810,93 @@ async function startTransformersStream(
   const { customInstructions } = await getSettings();
 
   try {
-    await withTransformersEngine(model, onProgress, async (eng) => {
-      if (action === "summarize") {
-        const effectiveLanguage = await resolveEffectiveLanguage(
-          content,
-          language,
-        );
-        const generator = summarizeText(
-          {
-            text: content,
-            title,
-            url,
-            mode,
-            type,
-            model,
-            language: effectiveLanguage,
-            customInstructions,
-            isSelection,
-            signal: stream.controller.signal,
-          },
-          {
-            translateFn,
-            chatStreamFn: async function* (_host, _model, prompt, opts) {
-              let count = 0;
-              for await (const token of transformersChatStream(eng, prompt, {
-                system: opts?.system,
-              })) {
-                if (stream.cancelled) return;
-                count++;
-                if (count % 24 === 0) {
-                  onProgress({
-                    progress: 0,
-                    text: `${longNote}${stageLabel} (${count} words)`,
-                  });
+    await withTransformersEngine(
+      model,
+      onProgress,
+      async (eng) => {
+        if (action === "summarize") {
+          const effectiveLanguage = await resolveEffectiveLanguage(
+            content,
+            language,
+          );
+          const generator = summarizeText(
+            {
+              text: content,
+              title,
+              url,
+              mode,
+              type,
+              model,
+              language: effectiveLanguage,
+              customInstructions,
+              isSelection,
+              signal: stream.controller.signal,
+            },
+            {
+              translateFn,
+              chatStreamFn: async function* (_host, _model, prompt, opts) {
+                let count = 0;
+                for await (const token of transformersChatStream(eng, prompt, {
+                  system: opts?.system,
+                })) {
+                  if (stream.cancelled) return;
+                  count++;
+                  if (count % 24 === 0) {
+                    onProgress({
+                      progress: 0,
+                      text: `${longNote}${stageLabel} (${count} words)`,
+                    });
+                  }
+                  yield token;
                 }
-                yield token;
-              }
+              },
+              onProgress: (p) => {
+                if (p.stage === "truncated") {
+                  longNote = "Long page - summarizing the key parts. ";
+                  onProgress({ progress: 0, text: longNote.trim() });
+                  return;
+                }
+                if (p.stage === "reduce") stageLabel = "Merging summary...";
+                else if (p.stage === "translate") stageLabel = "Translating...";
+                else
+                  stageLabel = `Summarizing part ${p.index + 1} of ${p.total}...`;
+                onProgress({ progress: 0, text: longNote + stageLabel });
+              },
             },
-            onProgress: (p) => {
-              if (p.stage === "truncated") {
-                longNote = "Long page - summarizing the key parts. ";
-                onProgress({ progress: 0, text: longNote.trim() });
-                return;
-              }
-              if (p.stage === "reduce") stageLabel = "Merging summary...";
-              else if (p.stage === "translate") stageLabel = "Translating...";
-              else
-                stageLabel = `Summarizing part ${p.index + 1} of ${p.total}...`;
-              onProgress({ progress: 0, text: longNote + stageLabel });
+          );
+          for await (const token of generator) {
+            emitChunk(token);
+          }
+        } else if (action === "ask") {
+          const relevantContent = await getRelevantAskContent(
+            content,
+            question,
+          );
+          const prompt = withCustomInstructions(
+            buildAnswerPrompt(title, url, relevantContent, question),
+            customInstructions,
+          );
+          const chat = (p, opts) =>
+            transformersChatStream(eng, p, { system: opts?.system });
+          const askLanguage = await resolveEffectiveLanguage(content, language);
+          for await (const token of streamInTargetLanguage(
+            chat,
+            prompt,
+            askLanguage,
+            {
+              signal: stream.controller.signal,
+              translateFn,
             },
-          },
-        );
-        for await (const token of generator) {
-          emitChunk(token);
+          )) {
+            if (stream.cancelled) break;
+            emitChunk(token);
+          }
+        } else {
+          throw new Error(`Unknown transformers-stream action: ${action}`);
         }
-      } else if (action === "ask") {
-        const relevantContent = await getRelevantAskContent(content, question);
-        const prompt = withCustomInstructions(
-          buildAnswerPrompt(title, url, relevantContent, question),
-          customInstructions,
-        );
-        const chat = (p, opts) =>
-          transformersChatStream(eng, p, { system: opts?.system });
-        const askLanguage = await resolveEffectiveLanguage(content, language);
-        for await (const token of streamInTargetLanguage(
-          chat,
-          prompt,
-          askLanguage,
-          {
-            signal: stream.controller.signal,
-            translateFn,
-          },
-        )) {
-          if (stream.cancelled) break;
-          emitChunk(token);
-        }
-      } else {
-        throw new Error(`Unknown transformers-stream action: ${action}`);
-      }
-    });
+      },
+      { signal: stream.controller.signal },
+    );
     finish({ type: "done" });
   } catch (err) {
     finish({

--- a/apogee-extension/lib/engines/transformersEngine.js
+++ b/apogee-extension/lib/engines/transformersEngine.js
@@ -7,6 +7,21 @@ import { getTransformers } from "./transformersLib.js";
 import { ortWasmUrl, ortWasmBinary } from "./onnxWasm.js";
 import { createLock } from "../util/mutex.js";
 
+export const ENGINE_LOCK_TIMEOUT_MS = 5 * 60 * 1000;
+const LOAD_MAX_ATTEMPTS = 3;
+
+export function isTransientLoadError(err) {
+  return /cache\.add|network\s?error|failed to fetch|fetch failed|terminated|timeout|econn|enotfound|socket|stall/i.test(
+    err?.message || "",
+  );
+}
+
+export function isEngineCorruptingError(err) {
+  return /out of memory|\boom\b|buffer allocation|gpubuffer|allocation failed|memory limit|disposed|destroyed|context (was )?lost|wasm.*(abort|trap|\boom\b)/i.test(
+    err?.message || "",
+  );
+}
+
 const GENERATION_MAX_TOKENS = 640;
 
 let engine = null;
@@ -28,6 +43,41 @@ function resolveWasmThreads(label) {
 }
 
 const acquireLock = createLock();
+
+async function loadPipeline(modelId, modelInfo, onProgress) {
+  const { pipeline, env } = await getTransformers();
+  debugLog("[transformers] library loaded, preparing WASM backend");
+  env.backends.onnx.wasm.numThreads = resolveWasmThreads("text-gen");
+  env.backends.onnx.wasm.wasmPaths = { wasm: ortWasmUrl() };
+  env.backends.onnx.wasm.wasmBinary = await ortWasmBinary();
+  debugLog("[transformers] WASM binary ready, building pipeline");
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await pipeline("text-generation", modelInfo.id, {
+        dtype: modelInfo.dtype,
+        device: "wasm",
+        progress_callback: (p) => {
+          if (p.status !== "progress") return;
+          onProgress?.({
+            progress: p.progress / 100,
+            text: `Downloading model... ${Math.round(p.progress)}%`,
+          });
+        },
+      });
+    } catch (err) {
+      debugLog(
+        `[transformers] load attempt ${attempt} failed: ${err?.message}`,
+      );
+      if (!isTransientLoadError(err) || attempt >= LOAD_MAX_ATTEMPTS) throw err;
+      onProgress?.({
+        progress: 0,
+        text: `Download hiccup - retrying (attempt ${attempt + 1} of ${LOAD_MAX_ATTEMPTS})...`,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+    }
+  }
+}
 
 async function ensureEngine(modelId, onProgress) {
   if (engine && currentModelId === modelId) {
@@ -52,24 +102,15 @@ async function ensureEngine(modelId, onProgress) {
   loadingModelId = modelId;
 
   debugLog(`[transformers] ensureEngine: loading ${modelId}`);
-  const { pipeline, env } = await getTransformers();
-  debugLog("[transformers] library loaded, preparing WASM backend");
-  env.backends.onnx.wasm.numThreads = resolveWasmThreads("text-gen");
-  env.backends.onnx.wasm.wasmPaths = { wasm: ortWasmUrl() };
-  env.backends.onnx.wasm.wasmBinary = await ortWasmBinary();
-  debugLog("[transformers] WASM binary ready, building pipeline");
-
-  engine = await pipeline("text-generation", modelInfo.id, {
-    dtype: modelInfo.dtype,
-    device: "wasm",
-    progress_callback: (p) => {
-      if (p.status !== "progress") return;
-      onProgress?.({
-        progress: p.progress / 100,
-        text: `Downloading model... ${Math.round(p.progress)}%`,
-      });
-    },
-  });
+  try {
+    engine = await loadPipeline(modelId, modelInfo, onProgress);
+  } catch (err) {
+    // Load failed: do not leave a stale loading flag behind.
+    engine = null;
+    currentModelId = null;
+    loadingModelId = null;
+    throw err;
+  }
   debugLog(`[transformers] pipeline ready for ${modelId}`);
 
   currentModelId = modelId;
@@ -91,14 +132,32 @@ function resetEngineState() {
   loadingModelId = null;
 }
 
-export async function withTransformersEngine(modelId, onProgress, fn) {
-  const release = await acquireLock();
+export async function withTransformersEngine(
+  modelId,
+  onProgress,
+  fn,
+  options = {},
+) {
+  const release = await acquireLock({
+    timeout: options.lockTimeout ?? ENGINE_LOCK_TIMEOUT_MS,
+    signal: options.signal,
+  });
   try {
+    // Load failures clean up in ensureEngine; never touch a healthy engine
+    // for them. A lock timeout/abort throws above, before we hold anything.
     const eng = await ensureEngine(modelId, onProgress);
-    return await fn(eng);
-  } catch (err) {
-    resetEngineState();
-    throw err;
+    try {
+      return await fn(eng);
+    } catch (err) {
+      // A transient inference failure must not discard a healthy multi-GB
+      // engine. Only drop it when the error shows the engine itself is
+      // corrupted (OOM / WASM abort) — otherwise the next stream would pay a
+      // full reload for no reason.
+      if (isEngineCorruptingError(err)) {
+        resetEngineState();
+      }
+      throw err;
+    }
   } finally {
     release();
   }
@@ -111,6 +170,56 @@ export function getTransformersStatus() {
 let translator = null;
 let translatorModelId = null;
 const acquireTranslatorLock = createLock();
+
+export const TRANSLATOR_IDLE_MS = 60 * 1000;
+let translatorIdleTimer = null;
+
+function cancelTranslatorIdleDispose() {
+  if (translatorIdleTimer) {
+    clearTimeout(translatorIdleTimer);
+    translatorIdleTimer = null;
+  }
+}
+
+function scheduleTranslatorIdleDispose() {
+  cancelTranslatorIdleDispose();
+  translatorIdleTimer = setTimeout(() => {
+    translatorIdleTimer = null;
+    disposeTranslatorNow();
+  }, TRANSLATOR_IDLE_MS);
+  if (translatorIdleTimer.unref) translatorIdleTimer.unref();
+}
+
+/** Dispose the cached translator so it stops contending WASM memory. */
+export function disposeTranslatorNow() {
+  cancelTranslatorIdleDispose();
+  if (translator) {
+    const stale = translator;
+    translator = null;
+    translatorModelId = null;
+    try {
+      Promise.resolve(stale.dispose()).catch(() => {});
+    } catch {
+      // Safe fallback: best-effort cleanup of idle translator
+    }
+    return true;
+  }
+  translatorModelId = null;
+  return false;
+}
+
+export function getTranslatorStatus() {
+  return {
+    currentModelId: translatorModelId,
+    idleDisposeScheduled: translatorIdleTimer !== null,
+  };
+}
+
+export function __setTranslatorForTest(t, modelId) {
+  cancelTranslatorIdleDispose();
+  translator = t;
+  translatorModelId = modelId;
+}
 
 async function ensureTranslator(modelId, onProgress) {
   if (translator && translatorModelId === modelId) return translator;
@@ -142,22 +251,48 @@ async function ensureTranslator(modelId, onProgress) {
   return translator;
 }
 
-export async function withTranslator(modelId, onProgress, fn) {
-  const release = await acquireTranslatorLock();
+export async function withTranslator(modelId, onProgress, fn, options = {}) {
+  const release = await acquireTranslatorLock({
+    timeout: options.lockTimeout ?? ENGINE_LOCK_TIMEOUT_MS,
+    signal: options.signal,
+  });
+  cancelTranslatorIdleDispose();
   try {
-    const t = await ensureTranslator(modelId, onProgress);
-    return await fn(t);
-  } catch (err) {
-    if (translator) {
-      try {
-        Promise.resolve(translator.dispose()).catch(() => {});
-      } catch {
-        // Safe fallback: best-effort cleanup of failed translator
+    let t;
+    try {
+      t = await ensureTranslator(modelId, onProgress);
+    } catch (err) {
+      if (translator) {
+        try {
+          Promise.resolve(translator.dispose()).catch(() => {});
+        } catch {
+          // Safe fallback: best-effort cleanup of failed translator
+        }
       }
+      translator = null;
+      translatorModelId = null;
+      throw err;
     }
-    translator = null;
-    translatorModelId = null;
-    throw err;
+    try {
+      return await fn(t);
+    } catch (err) {
+      // Same rule as the text engine: transient translation failures keep the
+      // cached translator; only corrupting errors drop it.
+      if (isEngineCorruptingError(err)) {
+        try {
+          Promise.resolve(translator.dispose()).catch(() => {});
+        } catch {
+          // Safe fallback: best-effort cleanup of failed translator
+        }
+        translator = null;
+        translatorModelId = null;
+      }
+      throw err;
+    } finally {
+      // Free WASM memory when the translator goes idle instead of holding it
+      // for the life of the page: summarize + translate otherwise contend.
+      if (translator) scheduleTranslatorIdleDispose();
+    }
   } finally {
     release();
   }

--- a/apogee-extension/lib/util/mutex.js
+++ b/apogee-extension/lib/util/mutex.js
@@ -87,6 +87,9 @@ export function createLock() {
       };
 
       if (timeout !== undefined) {
+        // No unref here: callers await this timer, so it must keep the event
+        // loop alive until it fires. (Unref would let the loop drain with the
+        // acquire still pending, cancelling the waiter.)
         waiter.timer = setTimeout(() => {
           if (waiter.settled) return;
           waiter.settled = true;
@@ -98,7 +101,6 @@ export function createLock() {
             ),
           );
         }, timeout);
-        if (waiter.timer.unref) waiter.timer.unref();
       }
 
       if (signal) {

--- a/apogee-extension/lib/util/mutex.js
+++ b/apogee-extension/lib/util/mutex.js
@@ -1,13 +1,172 @@
+export class MutexTimeoutError extends Error {
+  constructor(message = "Timed out waiting for lock") {
+    super(message);
+    this.name = "MutexTimeoutError";
+  }
+}
+
+export class MutexAbortError extends Error {
+  constructor(message = "Lock acquisition aborted") {
+    super(message);
+    this.name = "MutexAbortError";
+  }
+}
+
+function throwIfAborted(signal) {
+  if (signal?.aborted) {
+    throw new MutexAbortError(
+      signal.reason?.message || "Lock acquisition aborted",
+    );
+  }
+}
+
+/**
+ * FIFO mutex. `acquire()` waits forever (legacy behavior). Pass
+ * `{ timeout, signal }` to bound the wait: a stalled holder no longer
+ * head-of-line-blocks every later stream forever.
+ *
+ * Timed-out / aborted waiters are removed from the queue so the next
+ * waiter still gets the lock in order.
+ */
 export function createLock() {
-  let lock = Promise.resolve();
-  return async function acquire() {
-    let release;
-    const next = new Promise((resolve) => {
-      release = resolve;
+  let locked = false;
+  const waiters = [];
+
+  function pump() {
+    if (locked) return;
+    while (waiters.length > 0) {
+      const waiter = waiters.shift();
+      if (waiter.settled) continue;
+      waiter.settled = true;
+      if (waiter.timer) clearTimeout(waiter.timer);
+      waiter.signal?.removeEventListener("abort", waiter.onAbort);
+      locked = true;
+      waiter.resolve(makeRelease());
+      return;
+    }
+  }
+
+  function makeRelease() {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      locked = false;
+      pump();
+    };
+  }
+
+  async function acquire(options = {}) {
+    const { timeout, signal } =
+      typeof options === "number" ? { timeout: options } : (options ?? {});
+    throwIfAborted(signal);
+    if (timeout !== undefined) {
+      if (typeof timeout !== "number" || !(timeout > 0)) {
+        throw new TypeError("timeout must be a positive number of ms");
+      }
+    }
+
+    if (!locked) {
+      locked = true;
+      return makeRelease();
+    }
+
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        resolve,
+        reject,
+        settled: false,
+        signal,
+        timer: null,
+        onAbort: null,
+      };
+
+      const remove = () => {
+        const idx = waiters.indexOf(waiter);
+        if (idx !== -1) waiters.splice(idx, 1);
+      };
+
+      if (timeout !== undefined) {
+        waiter.timer = setTimeout(() => {
+          if (waiter.settled) return;
+          waiter.settled = true;
+          remove();
+          signal?.removeEventListener("abort", waiter.onAbort);
+          reject(
+            new MutexTimeoutError(
+              `Timed out after ${timeout}ms waiting for lock`,
+            ),
+          );
+        }, timeout);
+        if (waiter.timer.unref) waiter.timer.unref();
+      }
+
+      if (signal) {
+        waiter.onAbort = () => {
+          if (waiter.settled) return;
+          waiter.settled = true;
+          if (waiter.timer) clearTimeout(waiter.timer);
+          remove();
+          reject(
+            new MutexAbortError(
+              signal.reason?.message || "Lock acquisition aborted",
+            ),
+          );
+        };
+        signal.addEventListener("abort", waiter.onAbort, { once: true });
+      }
+
+      waiters.push(waiter);
     });
-    const previous = lock;
-    lock = next;
-    await previous;
-    return release;
+  }
+
+  acquire.tryAcquire = () => {
+    if (locked) return null;
+    locked = true;
+    return makeRelease();
   };
+
+  acquire.pendingCount = () => waiters.length;
+  acquire.isLocked = () => locked;
+
+  return acquire;
+}
+
+/**
+ * Per-key FIFO locks. Each key gets an independent mutex, so a stalled
+ * download of one engine/model does not head-of-line-block streams using
+ * a different engine/model. Locks are created lazily and shared per key.
+ */
+export function createKeyedLock() {
+  const locks = new Map();
+
+  function acquireFor(key, options) {
+    let lock = locks.get(key);
+    if (!lock) {
+      lock = createLock();
+      locks.set(key, lock);
+    }
+    return lock(options);
+  }
+
+  acquireFor.tryAcquire = (key) => {
+    let lock = locks.get(key);
+    if (!lock) {
+      lock = createLock();
+      locks.set(key, lock);
+    }
+    return lock.tryAcquire();
+  };
+
+  acquireFor.pendingCount = (key) => locks.get(key)?.pendingCount() ?? 0;
+  acquireFor.isLocked = (key) => locks.get(key)?.isLocked() ?? false;
+  acquireFor.keys = () => [...locks.keys()];
+  acquireFor.forget = (key) => {
+    const lock = locks.get(key);
+    if (lock && !lock.isLocked() && lock.pendingCount() === 0) {
+      locks.delete(key);
+    }
+  };
+
+  return acquireFor;
 }

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -106,6 +106,17 @@ let loadingModelId = null;
 
 const acquireLock = createLock();
 
+// Bound the wait for the WebLLM engine so one stalled model download does
+// not head-of-line-block every later stream forever. Downloads resume from
+// cache, so failing fast with a clear message beats hanging.
+const ENGINE_LOCK_TIMEOUT_MS = 5 * 60 * 1000;
+
+function isCorruptingEngineError(err) {
+  return /out of memory|\boom\b|buffer allocation|gpubuffer|allocation failed|memory limit|disposed|destroyed|context (was )?lost/i.test(
+    err?.message || "",
+  );
+}
+
 let engineOwnerStreamId = null;
 
 let _webllm = null;
@@ -213,8 +224,12 @@ async function ensureEngine(modelId) {
         break;
       } catch (err) {
         console.error(`Model load attempt ${attempt} failed:`, err);
-        if (!isInterruptedDownloadError(err)) throw err;
+        if (!isInterruptedDownloadError(err)) {
+          loadingModelId = null;
+          throw err;
+        }
         if (attempt >= MAX_DOWNLOAD_ATTEMPTS) {
+          loadingModelId = null;
           throw new Error(
             "The model download keeps getting interrupted (the download " +
               "server stalled or the connection dropped). Progress so far " +
@@ -249,15 +264,35 @@ function resetEngineState() {
   loadingModelId = null;
 }
 
-async function withEngine(modelId, fn, ownerStreamId = null) {
-  const release = await acquireLock();
-  engineOwnerStreamId = ownerStreamId;
+async function withEngine(modelId, fn, ownerStreamId = null, options = {}) {
+  // Allow (modelId, fn, { signal, lockTimeout }) as well as the legacy
+  // (modelId, fn, streamId) shape.
+  let owner = ownerStreamId;
+  let opts = options;
+  if (ownerStreamId && typeof ownerStreamId === "object") {
+    opts = ownerStreamId;
+    owner = opts.ownerStreamId ?? null;
+  }
+  const release = await acquireLock({
+    timeout: opts.lockTimeout ?? ENGINE_LOCK_TIMEOUT_MS,
+    signal: opts.signal,
+  });
+  engineOwnerStreamId = owner;
   try {
+    // Load failures already cleared loading state; a lock timeout/abort
+    // throws above before we hold anything, so never discard here.
     const eng = await ensureEngine(modelId);
-    return await fn(eng);
-  } catch (err) {
-    resetEngineState();
-    throw err;
+    try {
+      return await fn(eng);
+    } catch (err) {
+      // A transient generation failure must not discard a healthy multi-GB
+      // engine. Only drop it when the error shows the engine itself is
+      // corrupted (OOM); otherwise the next stream would pay a full reload.
+      if (isCorruptingEngineError(err)) {
+        resetEngineState();
+      }
+      throw err;
+    }
   } finally {
     engineOwnerStreamId = null;
     release();
@@ -521,6 +556,7 @@ async function runTransformersJob(
         emit({ type: "error", error: `Unknown action: ${pending.action}` });
       }
     },
+    { signal },
   );
 }
 
@@ -645,7 +681,7 @@ async function runStream(streamId, pending, stream) {
               });
           }
         },
-        streamId,
+        { ownerStreamId: streamId, signal: controller.signal },
       );
     }
   } catch (err) {

--- a/apogee-extension/tests/engines/transformersMutex.test.js
+++ b/apogee-extension/tests/engines/transformersMutex.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert";
+import {
+  isTransientLoadError,
+  isEngineCorruptingError,
+  withTranslator,
+  disposeTranslatorNow,
+  getTranslatorStatus,
+  __setTranslatorForTest,
+} from "../../lib/engines/transformersEngine.js";
+
+test("transient load errors are retried; corrupting errors are not transient", () => {
+  assert.equal(
+    isTransientLoadError(new Error("network error: failed to fetch")),
+    true,
+  );
+  assert.equal(isTransientLoadError(new Error("cache.add failed")), true);
+  assert.equal(isTransientLoadError(new Error("out of memory")), false);
+  assert.equal(isTransientLoadError(new Error("boom")), false);
+});
+
+test("only corrupting errors discard the engine", () => {
+  assert.equal(isEngineCorruptingError(new Error("out of memory")), true);
+  assert.equal(
+    isEngineCorruptingError(new Error("OOM while allocating GPUBuffer")),
+    true,
+  );
+  assert.equal(
+    isEngineCorruptingError(new Error("network error: failed to fetch")),
+    false,
+  );
+  assert.equal(isEngineCorruptingError(new Error("boom")), false);
+});
+
+test("withTranslator keeps the cached translator on a transient failure", async (t) => {
+  t.after(() => disposeTranslatorNow());
+  let disposed = 0;
+  const fake = {
+    dispose: async () => {
+      disposed++;
+    },
+  };
+  __setTranslatorForTest(fake, "opus-mt-en-fr");
+
+  await assert.rejects(
+    withTranslator("opus-mt-en-fr", null, async () => {
+      throw new Error("network error: failed to fetch");
+    }),
+    /network error/,
+  );
+
+  // Healthy engine kept: no reload needed for the next stream.
+  assert.strictEqual(disposed, 0);
+  assert.strictEqual(getTranslatorStatus().currentModelId, "opus-mt-en-fr");
+});
+
+test("withTranslator drops the cached translator on a corrupting failure", async (t) => {
+  t.after(() => disposeTranslatorNow());
+  let disposed = 0;
+  const fake = {
+    dispose: async () => {
+      disposed++;
+    },
+  };
+  __setTranslatorForTest(fake, "opus-mt-en-fr");
+
+  await assert.rejects(
+    withTranslator("opus-mt-en-fr", null, async () => {
+      throw new Error("out of memory");
+    }),
+    /out of memory/,
+  );
+
+  assert.strictEqual(disposed, 1);
+  assert.strictEqual(getTranslatorStatus().currentModelId, null);
+});
+
+test("idle translator is disposed instead of contending WASM memory", async () => {
+  let disposed = 0;
+  const fake = {
+    dispose: async () => {
+      disposed++;
+    },
+  };
+  __setTranslatorForTest(fake, "opus-mt-en-fr");
+
+  assert.strictEqual(disposeTranslatorNow(), true);
+  assert.strictEqual(disposed, 1);
+  assert.strictEqual(getTranslatorStatus().currentModelId, null);
+  assert.strictEqual(disposeTranslatorNow(), false);
+});

--- a/apogee-extension/tests/util/mutex.test.js
+++ b/apogee-extension/tests/util/mutex.test.js
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert";
-import { createLock } from "../../lib/util/mutex.js";
+import {
+  createLock,
+  createKeyedLock,
+  MutexAbortError,
+  MutexTimeoutError,
+} from "../../lib/util/mutex.js";
 
 test("acquire and release: a second acquire resolves after the first is released", async () => {
   const acquire = createLock();
@@ -81,4 +86,104 @@ test("ordering: multiple waiters are served in FIFO order", async () => {
   await Promise.all([p2, p3, p4]);
 
   assert.deepStrictEqual(order, ["2", "3", "4"]);
+});
+
+test("contention/timeout: a stalled holder does not block waiters forever", async () => {
+  const acquire = createLock();
+  const release1 = await acquire();
+
+  // Second waiter gives up after 20ms instead of hanging forever behind the
+  // stalled model download.
+  await assert.rejects(acquire({ timeout: 20 }), MutexTimeoutError);
+
+  // The timed-out waiter left the queue: the next waiter still gets the lock
+  // in order once the holder releases.
+  const order = [];
+  const p3 = acquire({ timeout: 1000 }).then((release) => {
+    order.push("3");
+    release();
+  });
+  release1();
+  await p3;
+  assert.deepStrictEqual(order, ["3"]);
+});
+
+test("contention/timeout: queue keeps FIFO order after a timeout", async () => {
+  const acquire = createLock();
+  const release1 = await acquire();
+
+  const order = [];
+  const pTimeout = acquire({ timeout: 20 }).then(
+    () => order.push("timeout-acquired-unexpectedly"),
+    (err) => {
+      assert.ok(err instanceof MutexTimeoutError);
+      order.push("timed-out");
+    },
+  );
+  const pNext = acquire({ timeout: 1000 }).then((release) => {
+    order.push("next");
+    release();
+  });
+
+  await pTimeout;
+  assert.deepStrictEqual(order, ["timed-out"]);
+  assert.strictEqual(acquire.pendingCount(), 1);
+
+  release1();
+  await pNext;
+  assert.deepStrictEqual(order, ["timed-out", "next"]);
+});
+
+test("abort: a cancelled stream stops waiting for the lock", async () => {
+  const acquire = createLock();
+  const release1 = await acquire();
+
+  const controller = new AbortController();
+  const waiting = acquire({ signal: controller.signal }).then(
+    () => "acquired-unexpectedly",
+    (err) => err,
+  );
+  controller.abort();
+  const err = await waiting;
+  assert.ok(err instanceof MutexAbortError);
+
+  // The aborted waiter left the queue.
+  assert.strictEqual(acquire.pendingCount(), 0);
+  release1();
+  const release2 = await acquire({ timeout: 100 });
+  release2();
+});
+
+test("abort: already-aborted signal never acquires", async () => {
+  const acquire = createLock();
+  const release1 = await acquire();
+  try {
+    const controller = new AbortController();
+    controller.abort();
+    await assert.rejects(
+      acquire({ signal: controller.signal }),
+      MutexAbortError,
+    );
+  } finally {
+    release1();
+  }
+});
+
+test("keyed: a stalled engine does not block a different engine", async () => {
+  const acquire = createKeyedLock();
+  const releaseA = await acquire("webllm");
+
+  // Same key waits; different key proceeds immediately.
+  let sameKeyAcquired = false;
+  const sameKey = acquire("webllm", { timeout: 1000 }).then((release) => {
+    sameKeyAcquired = true;
+    release();
+  });
+  const releaseB = await acquire("transformers", { timeout: 50 });
+  releaseB();
+
+  assert.strictEqual(sameKeyAcquired, false);
+  releaseA();
+  await sameKey;
+  assert.strictEqual(sameKeyAcquired, true);
 });


### PR DESCRIPTION
Fixes #268.

- mutex: timeout/abort FIFO lock plus keyed locks so one stalled download no longer blocks all streams.
- transformers/WebLLM engines: only discard on corrupting (OOM/WASM) errors; transient failures keep the loaded engine. Transformers load retries transient errors.
- translator: idle disposal after 60s to reduce WASM memory contention.
- callers pass abort signals; lock wait aborts on stream cancel.
- tests: mutex contention/timeout/abort/keyed plus translator keep/drop and idle-dispose coverage. Full suite: 624 pass, ESLint clean.