### PR TITLE
fix: bound SW/offscreen ingress, cap map chunks and stream text (#269)

### DIFF
--- a/apogee-extension/background/service-worker.js
+++ b/apogee-extension/background/service-worker.js
@@ -44,6 +44,8 @@ import {
   MAX_BILIBILI_SUBTITLE_SEGMENTS,
   MAX_FINALIZE_TEXT_CHARS,
   MAX_UPLOAD_FILE_BYTES,
+  appendStreamTextCapped,
+  assertIngressPayloadOk,
 } from "../lib/extract/fileLimits.js";
 import {
   recordPageAccessEvent,
@@ -599,10 +601,17 @@ function createBufferedStream(streamId, { finalize, model, title, url }) {
 
   const emitChunk = (text) => {
     if (!text || stream.cancelled) return;
-    stream.text += text;
+    // Bound live accumulation pre-cap (#269): finalize caps at write time,
+    // but stream.text grows with every token before that. Keep the head and
+    // drop the tail so a runaway model cannot bloat SW memory.
+    const capped = appendStreamTextCapped(stream.text, text);
+    const accepted = capped.text.length - stream.text.length;
+    stream.text = capped.text;
     if (stream.firstTokenTime == null)
       stream.firstTokenTime = performance.now();
-    stream.tokenCount += tokensForChunk(text);
+    stream.tokenCount += tokensForChunk(
+      accepted > 0 ? text.slice(0, accepted) : "",
+    );
     broadcastToStream(stream, { type: "chunk", text });
     const elapsedMs = performance.now() - stream.firstTokenTime;
     if (isWarmedUp(stream.tokenCount, elapsedMs)) {
@@ -642,6 +651,20 @@ async function startLocalHttpStream(
     title,
     url,
   });
+
+  // Ingress bound (#269): payloads arrive via extension messaging unbounded;
+  // reject oversize with a UserFacingError before chunking fans out into
+  // sequential model calls.
+  try {
+    assertIngressPayloadOk({ content, question, title, url });
+  } catch (err) {
+    finish({
+      type: "error",
+      error: err.message,
+      userFacing: !!err?.isUserFacing,
+    });
+    return;
+  }
 
   let validHost;
   try {
@@ -790,6 +813,17 @@ async function startTransformersStream(
     title,
     url,
   });
+
+  try {
+    assertIngressPayloadOk({ content, question, title, url });
+  } catch (err) {
+    finish({
+      type: "error",
+      error: err.message,
+      userFacing: !!err?.isUserFacing,
+    });
+    return;
+  }
 
   const onProgress = (progress) => {
     chrome.runtime
@@ -1920,6 +1954,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       switch (message.action) {
         case "summarize":
         case "ask": {
+          assertIngressPayloadOk(message.payload || {});
           await ensureOffscreenDocument();
 
           const streamId = nextStreamId("webllm");
@@ -1947,6 +1982,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         case "ollama-stream": {
+          assertIngressPayloadOk(message.payload || {});
           const streamId = nextStreamId("ollama");
           const settings = await getSettings();
           const trustedFinalize =
@@ -1965,6 +2001,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         case "llamacpp-stream": {
+          assertIngressPayloadOk(message.payload || {});
           const streamId = nextStreamId("llamacpp");
           const settings = await getSettings();
           const trustedFinalize =
@@ -2044,6 +2081,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         case "transformers-stream": {
+          assertIngressPayloadOk(message.payload || {});
           const streamId = nextStreamId("transformers");
           const settings = await getSettings();
           const trustedFinalize =
@@ -2167,6 +2205,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         case "find-passage": {
+          assertIngressPayloadOk(message.payload || {});
           if (!hasOffscreenAPI) {
             try {
               const { content, query } = message.payload || {};
@@ -2188,6 +2227,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         case "retrieve-context": {
+          assertIngressPayloadOk(message.payload || {});
           if (!hasOffscreenAPI) {
             try {
               const { content, question } = message.payload || {};

--- a/apogee-extension/lib/extract/fileLimits.js
+++ b/apogee-extension/lib/extract/fileLimits.js
@@ -96,6 +96,60 @@ export function truncateExtractedText(text, label = "file") {
   return { text: `${head}\n\n${note}`, truncated: true };
 }
 
+// SW/offscreen ingress hardening (#269). summarize/ask/retrieve-context
+// payloads cross extension messaging unbounded today; only the UI-side
+// pasted cap and the 1 MB finalize backstop bound them, while stream.text
+// accumulates pre-cap and the map-every-chunk path turns a giant hostile
+// page into many sequential model calls. Content past this ceiling is
+// rejected with a UserFacingError at the trust boundary; title/url/question
+// reuse the prompt-fencing ceilings so one set of numbers guards both.
+export const MAX_INGRESS_CONTENT_CHARS = MAX_FINALIZE_TEXT_CHARS;
+export const MAX_INGRESS_TITLE_CHARS = 500;
+export const MAX_INGRESS_URL_CHARS = 2000;
+export const MAX_INGRESS_QUESTION_CHARS = 2000;
+export const MAX_INGRESS_PROMPT_CHARS = MAX_FINALIZE_TEXT_CHARS;
+
+// Absolute map-stage ceiling (#269). getMaxChunks bounds the reduce budget
+// per model, but the no-selector fallback keeps every chunk, so a 1 MB
+// hostile page is still dozens of sequential model calls. Capping mapped
+// chunks bounds total calls regardless of ingress size.
+export const MAX_ABSOLUTE_MAP_CHUNKS = 64;
+
+// Live stream-text ceiling (#269). finalizeSummaryJob caps at write time,
+// but stream.text grows with every token before that. Stop accumulating
+// past the same 1 MB so a runaway model cannot bloat SW/offscreen memory.
+export const MAX_STREAM_TEXT_CHARS = MAX_FINALIZE_TEXT_CHARS;
+
+function ingressLength(value) {
+  return typeof value === "string" ? value.length : 0;
+}
+
+export function assertIngressPayloadOk(payload = {}) {
+  const { content, question, query, title, url, summary, prompt } = payload;
+  const checks = [
+    [content, MAX_INGRESS_CONTENT_CHARS, "content"],
+    [question, MAX_INGRESS_QUESTION_CHARS, "question"],
+    [query, MAX_INGRESS_QUESTION_CHARS, "question"],
+    [title, MAX_INGRESS_TITLE_CHARS, "title"],
+    [url, MAX_INGRESS_URL_CHARS, "URL"],
+    [summary, MAX_INGRESS_CONTENT_CHARS, "summary"],
+    [prompt, MAX_INGRESS_PROMPT_CHARS, "prompt"],
+  ];
+  for (const [value, max, label] of checks) {
+    if (ingressLength(value) > max) {
+      throw new UserFacingError(
+        `This ${label} exceeds the ${max.toLocaleString()} character limit for in-extension processing. Try a shorter document.`,
+      );
+    }
+  }
+}
+
+export function appendStreamTextCapped(current, addition) {
+  const text = `${current || ""}${addition || ""}`;
+  if (text.length <= MAX_STREAM_TEXT_CHARS) return { text, truncated: false };
+  return { text: text.slice(0, MAX_STREAM_TEXT_CHARS), truncated: true };
+}
+
 // Slice size for incremental base64 encoding below. Must stay a multiple of 3
 // so each slice encodes to a whole number of base64 quanta and slices can be
 // encoded independently without corrupting boundary bytes.

--- a/apogee-extension/lib/summarize/mapReduce.js
+++ b/apogee-extension/lib/summarize/mapReduce.js
@@ -1,5 +1,6 @@
 import { cleanText } from "./cleaner.js";
 import { getMaxChunkChars, getMaxChunks } from "../engines/modelLimits.js";
+import { MAX_ABSOLUTE_MAP_CHUNKS } from "../extract/fileLimits.js";
 import { streamInTargetLanguage } from "../language/languageOutput.js";
 
 const OOM_PATTERN =
@@ -155,6 +156,18 @@ export async function* mapReduceStream(
   const maxChunks = getMaxChunks(model);
   if (chunks.length > maxChunks) {
     chunks = choosePartialChunks(chunks, maxChunks, selectChunksFn, onProgress);
+  }
+  // Absolute map-stage ceiling (#269). The no-selector fallback keeps every
+  // chunk, so a hostile 1 MB page is still dozens of sequential model calls
+  // even after the per-model budget above. Hard-cap mapped chunks so total
+  // calls stay bounded regardless of ingress size.
+  if (chunks.length > MAX_ABSOLUTE_MAP_CHUNKS) {
+    onProgress?.({
+      stage: "truncated",
+      kept: MAX_ABSOLUTE_MAP_CHUNKS,
+      total: chunks.length,
+    });
+    chunks = chunks.slice(0, MAX_ABSOLUTE_MAP_CHUNKS);
   }
   if (signal?.aborted) return;
 

--- a/apogee-extension/offscreen/offscreen.js
+++ b/apogee-extension/offscreen/offscreen.js
@@ -25,6 +25,10 @@ import {
 import { initDebugLogging } from "../lib/util/log.js";
 import { broadcastToStream } from "../lib/util/streamBroadcast.js";
 import {
+  appendStreamTextCapped,
+  assertIngressPayloadOk,
+} from "../lib/extract/fileLimits.js";
+import {
   tokensForChunk,
   isWarmedUp,
   tokensPerSecond,
@@ -567,7 +571,9 @@ async function runStream(streamId, pending, stream) {
   const emit = (msg) => {
     if (stream.cancelled) return;
     if (msg.type === "chunk") {
-      stream.text += msg.text || "";
+      // Bound live accumulation pre-cap (#269): keep the head, drop the tail.
+      const capped = appendStreamTextCapped(stream.text, msg.text || "");
+      stream.text = capped.text;
       if (stream.firstTokenTime == null) {
         stream.firstTokenTime = performance.now();
       }
@@ -794,6 +800,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       switch (message.action) {
         case "summarize":
         case "ask": {
+          assertIngressPayloadOk(message.payload || {});
           const streamId = message.streamId;
           const stream = {
             text: "",
@@ -843,6 +850,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         case "retrieve-context": {
+          assertIngressPayloadOk(message.payload || {});
           const { content, question } = message.payload;
           const relevantContent = await retrieveRelevantContent({
             content,
@@ -853,6 +861,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         case "find-passage": {
+          assertIngressPayloadOk(message.payload || {});
           const { content, query } = message.payload;
           const passage = await findBestPassage({ content, query });
           sendResponse({ passage });
@@ -860,6 +869,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         case "suggest-questions": {
+          assertIngressPayloadOk(message.payload || {});
           const {
             title,
             url,
@@ -919,6 +929,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             sendResponse({ error: "generate-text requires a prompt" });
             break;
           }
+          assertIngressPayloadOk({ prompt });
           const qLanguage = await resolveEffectiveLanguage("", language);
           const translateFn = opusTranslateFor(translationEngine);
           const text =

--- a/apogee-extension/tests/extract/ingressLimits.test.js
+++ b/apogee-extension/tests/extract/ingressLimits.test.js
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MAX_ABSOLUTE_MAP_CHUNKS,
+  MAX_INGRESS_CONTENT_CHARS,
+  MAX_INGRESS_PROMPT_CHARS,
+  MAX_INGRESS_QUESTION_CHARS,
+  MAX_INGRESS_TITLE_CHARS,
+  MAX_INGRESS_URL_CHARS,
+  MAX_STREAM_TEXT_CHARS,
+  appendStreamTextCapped,
+  assertIngressPayloadOk,
+} from "../../lib/extract/fileLimits.js";
+import { mapReduceStream } from "../../lib/summarize/mapReduce.js";
+
+test("ingress ceilings reuse the prompt-fencing and finalize backstops (#269)", () => {
+  assert.equal(MAX_INGRESS_TITLE_CHARS, 500);
+  assert.equal(MAX_INGRESS_URL_CHARS, 2000);
+  assert.equal(MAX_INGRESS_QUESTION_CHARS, 2000);
+  assert.equal(MAX_INGRESS_CONTENT_CHARS, 1024 * 1024);
+  assert.equal(MAX_INGRESS_PROMPT_CHARS, 1024 * 1024);
+  assert.equal(MAX_STREAM_TEXT_CHARS, 1024 * 1024);
+  assert.equal(MAX_ABSOLUTE_MAP_CHUNKS, 64);
+});
+
+test("assertIngressPayloadOk passes payloads at the ceiling (#269)", () => {
+  assertIngressPayloadOk({
+    content: "x".repeat(MAX_INGRESS_CONTENT_CHARS),
+    question: "q".repeat(MAX_INGRESS_QUESTION_CHARS),
+    title: "t".repeat(MAX_INGRESS_TITLE_CHARS),
+    url: "u".repeat(MAX_INGRESS_URL_CHARS),
+  });
+  assertIngressPayloadOk({});
+  assertIngressPayloadOk({ content: undefined, question: null });
+});
+
+test("assertIngressPayloadOk rejects oversize fields with UserFacingError (#269)", () => {
+  for (const payload of [
+    { content: "x".repeat(MAX_INGRESS_CONTENT_CHARS + 1) },
+    { question: "q".repeat(MAX_INGRESS_QUESTION_CHARS + 1) },
+    { query: "q".repeat(MAX_INGRESS_QUESTION_CHARS + 1) },
+    { title: "t".repeat(MAX_INGRESS_TITLE_CHARS + 1) },
+    { url: "u".repeat(MAX_INGRESS_URL_CHARS + 1) },
+    { summary: "s".repeat(MAX_INGRESS_CONTENT_CHARS + 1) },
+    { prompt: "p".repeat(MAX_INGRESS_PROMPT_CHARS + 1) },
+  ]) {
+    assert.throws(
+      () => assertIngressPayloadOk(payload),
+      (err) => {
+        assert.equal(err.isUserFacing, true);
+        assert.match(err.message, /character limit/);
+        return true;
+      },
+    );
+  }
+});
+
+test("appendStreamTextCapped bounds live accumulation pre-cap (#269)", () => {
+  const small = appendStreamTextCapped("hello ", "world");
+  assert.equal(small.text, "hello world");
+  assert.equal(small.truncated, false);
+
+  const capped = appendStreamTextCapped(
+    "a".repeat(MAX_STREAM_TEXT_CHARS - 5),
+    "b".repeat(100),
+  );
+  assert.equal(capped.text.length, MAX_STREAM_TEXT_CHARS);
+  assert.equal(capped.truncated, true);
+});
+
+test("mapReduceStream hard-caps mapped chunks so hostile input cannot fan out (#269)", async () => {
+  let calls = 0;
+  async function* chatStreamFn() {
+    calls += 1;
+    yield "x";
+  }
+  const chunks = Array.from(
+    { length: MAX_ABSOLUTE_MAP_CHUNKS + 36 },
+    (_, i) => `c${i}`,
+  );
+  const progress = [];
+  const out = [];
+  for await (const token of mapReduceStream(
+    { text: "irrelevant", model: "m", host: "h" },
+    {
+      chunkTextFn: () => chunks,
+      chatStreamFn,
+      onProgress: (p) => progress.push(p),
+    },
+    {
+      buildSingle: (c) => `SINGLE: ${c}`,
+      buildMap: (c, i, t) => `MAP[${i}/${t}]: ${c}`,
+      buildReduce: (ps) => `REDUCE(${ps.length}): ${ps.join(" | ")}`,
+    },
+  )) {
+    out.push(token);
+  }
+
+  assert.ok(
+    progress.some(
+      (p) =>
+        p.stage === "truncated" &&
+        p.kept === MAX_ABSOLUTE_MAP_CHUNKS &&
+        p.total === chunks.length,
+    ),
+    "absolute cap must emit a truncated event with kept/total",
+  );
+  // 64 map + tree + final stays bounded; uncapped it would be 100 map calls.
+  assert.ok(calls < 100, `expected bounded calls, saw ${calls}`);
+  assert.ok(out.length >= 1);
+});


### PR DESCRIPTION
Reject oversize summarize/ask/retrieve-context payloads with UserFacingError at the SW and offscreen boundaries. Hard-cap mapped chunks at 64 so hostile pages cannot fan out into unbounded sequential model calls. Cap live stream.text at 1 MB pre-finalize. Fixes #269.